### PR TITLE
chore: changed the top-level module name to a name different from the crate name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,7 @@ license = "MIT"
 keywords = ["framework", "logic", "dataaccess", "dax"]
 categories = []
 
+[lib]
+name = "sabi"
+
 [dependencies]


### PR DESCRIPTION
T/O.