### PR TITLE
update: renamed DataSrc/DataConn to DaxSrc/DaxConn

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,7 +23,7 @@ pub enum AsyncGroup {
 ///
 /// The variants of this enum indicates the possible errors that may occur with `DataSrc`
 #[derive(Debug)]
-pub enum DataSrc {
+pub enum DaxSrc {
     /// The error reason which indicates that some DataSrc(s) failed to set up.
     FailToSetupGlobal {
         /// The map of which keys are the registered names of DataSrc(s) that failed, and of which

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 // See the file LICENSE in this distribution for more details.
 
 mod async_group;
-mod data_src;
+mod dax_src;
 mod errs;
 
 /// Enums for errors that can occur in this `sabi` crate.
@@ -13,10 +13,10 @@ pub use errs::Err;
 
 pub use async_group::AsyncGroup;
 
-pub use data_src::DataConn;
-pub use data_src::DataSrc;
+pub use dax_src::DaxConn;
+pub use dax_src::DaxSrc;
 
-pub use data_src::close;
-pub use data_src::setup;
-pub use data_src::start_app;
-pub use data_src::uses;
+pub use dax_src::close;
+pub use dax_src::setup;
+pub use dax_src::start_app;
+pub use dax_src::uses;


### PR DESCRIPTION
I tried implementing sabi's `DaxSrc`/`DaxConn` under a different name, but I eventually decided that `DaxSrc`/`DaxConn` was better, so I chose to name it that way.