### PR TITLE
update: changed the API of AsyncGroup#join

### DIFF
--- a/src/async_group.rs
+++ b/src/async_group.rs
@@ -180,23 +180,23 @@ mod tests_async_group {
         #[cfg(unix)]
         assert_eq!(
             format!("{:?}", *(m.get("foo1").unwrap())),
-            "errs::Err { reason = sabi::async_group::tests_async_group::Reasons BadString(\"hello\"), file = src/async_group.rs, line = 157 }"
+            "errs::Err { reason = sabi::async_group::tests_async_group::Reasons BadString(\"hello\"), file = src/async_group.rs, line = 158 }"
         );
         #[cfg(windows)]
         assert_eq!(
             format!("{:?}", *(m.get("foo1").unwrap())),
-            "errs::Err { reason = sabi::async_group::tests_async_group::Reasons BadString(\"hello\"), file = src\\async_group.rs, line = 157 }"
+            "errs::Err { reason = sabi::async_group::tests_async_group::Reasons BadString(\"hello\"), file = src\\async_group.rs, line = 158 }"
         );
 
         #[cfg(unix)]
         assert_eq!(
             format!("{:?}", *(m.get("foo2").unwrap())),
-            "errs::Err { reason = sabi::async_group::tests_async_group::Reasons BadFlag(true), file = src/async_group.rs, line = 162 }"
+            "errs::Err { reason = sabi::async_group::tests_async_group::Reasons BadFlag(true), file = src/async_group.rs, line = 163 }"
         );
         #[cfg(windows)]
         assert_eq!(
             format!("{:?}", *(m.get("foo2").unwrap())),
-            "errs::Err { reason = sabi::async_group::tests_async_group::Reasons BadFlag(true), file = src\\async_group.rs, line = 162 }"
+            "errs::Err { reason = sabi::async_group::tests_async_group::Reasons BadFlag(true), file = src\\async_group.rs, line = 163 }"
         );
     }
 }

--- a/src/dax/mod.rs
+++ b/src/dax/mod.rs
@@ -367,7 +367,7 @@ impl DaxConnMap {
         }
 
         let mut err_map = HashMap::new();
-        ag.join(&err_map);
+        ag.join(&mut err_map);
     }
 
     fn close(&self) {

--- a/src/dax/mod.rs
+++ b/src/dax/mod.rs
@@ -244,7 +244,7 @@ impl DaxSrcList {
             ptr = next;
         }
 
-        let err_map = ag.join();
+        ag.join(&mut err_map);
 
         err_map
     }
@@ -264,7 +264,8 @@ impl DaxSrcList {
             ptr = prev;
         }
 
-        let _ = ag.join();
+        let mut err_map = HashMap::new();
+        ag.join(&mut err_map);
     }
 }
 
@@ -322,6 +323,7 @@ impl DaxConnMap {
         }
 
         let mut ag = AsyncGroup::new();
+        let mut err_map = HashMap::new();
 
         let mut ptr = self.head;
         while !ptr.is_null() {
@@ -329,12 +331,12 @@ impl DaxConnMap {
             let name = unsafe { &(*ptr).name };
             let next = unsafe { (*ptr).next };
             if let Err(err) = commit_fn(ptr, &mut ag) {
-                //err_map.insert(name.to_string(), err);
+                err_map.insert(name.to_string(), err);
             }
             ptr = next;
         }
 
-        let err_map = ag.join();
+        ag.join(&mut err_map);
 
         if err_map.is_empty() {
             return Ok(());
@@ -364,7 +366,8 @@ impl DaxConnMap {
             ptr = next;
         }
 
-        let _ = ag.join();
+        let mut err_map = HashMap::new();
+        ag.join(&err_map);
     }
 
     fn close(&self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,14 @@
 // See the file LICENSE in this distribution for more details.
 
 mod async_group;
-//mod dax;
+mod dax;
 
 /// Enums for errors that can occur in this `sabi` crate.
 pub mod errors;
 
 pub use async_group::AsyncGroup;
-//pub use dax::DaxBaseImpl;
-//pub use dax::{close, setup, start_app, uses};
+pub use dax::DaxBaseImpl;
+pub use dax::{close, setup, start_app, uses};
 
 use errs::Err;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,14 @@
 // See the file LICENSE in this distribution for more details.
 
 mod async_group;
-mod dax;
+//mod dax;
 
 /// Enums for errors that can occur in this `sabi` crate.
 pub mod errors;
 
 pub use async_group::AsyncGroup;
-pub use dax::DaxBaseImpl;
-pub use dax::{close, setup, start_app, uses};
+//pub use dax::DaxBaseImpl;
+//pub use dax::{close, setup, start_app, uses};
 
 use errs::Err;
 


### PR DESCRIPTION
This PR changed the API of `AsyncGroup#join`, though this method is `pub(crate)`.