### PR TITLE
fix: modified the check of GLOBAL_DATA_SRCS_FIXED.get in uses function

### DIFF
--- a/src/data_hub.rs
+++ b/src/data_hub.rs
@@ -83,7 +83,7 @@ where
     C: DataConn + 'static,
 {
     #[cfg(not(test))]
-    let fixed = GLOBAL_DATA_SRCS_FIXED.get().is_none();
+    let fixed = GLOBAL_DATA_SRCS_FIXED.get().is_some();
     #[cfg(test)]
     let fixed = GLOBAL_DATA_SRCS_FIXED.load(sync::atomic::Ordering::Relaxed);
 


### PR DESCRIPTION
In `uses` function, there was an error in determining whether `GLOBAL_DATA_SRCS_FIXED` had been initialized.
This PR modifies it.