### PR TITLE
update: changed setup to terminate immediately and return an error map if an error occurs

### DIFF
--- a/src/data_acc.rs
+++ b/src/data_acc.rs
@@ -555,11 +555,8 @@ mod tests_of_data_acc {
                 *logger.lock().unwrap(),
                 vec![
                     "FooDataSrc 1 failed to setup",
-                    "BarDataSrc 2 setupped",
-                    "FooDataSrc 1 dropped",
-                    "BarDataSrc.text = ",
-                    "BarDataSrc 2 closed",
                     "BarDataSrc 2 dropped",
+                    "FooDataSrc 1 dropped",
                 ],
             );
         }
@@ -854,11 +851,8 @@ mod tests_of_data_acc {
                 *logger.lock().unwrap(),
                 vec![
                     "FooDataSrc 1 failed to setup",
-                    "BarDataSrc 2 setupped",
-                    "FooDataSrc 1 dropped",
-                    "BarDataSrc.text = ",
-                    "BarDataSrc 2 closed",
                     "BarDataSrc 2 dropped",
+                    "FooDataSrc 1 dropped",
                 ],
             );
         }

--- a/src/data_hub.rs
+++ b/src/data_hub.rs
@@ -1064,8 +1064,8 @@ mod tests_data_hub {
                 vec![
                     "SyncDataSrc 2 failed to setup",
                     "AsyncDataSrc 1 failed to setup",
-                    "AsyncDataSrc 1 dropped",
                     "SyncDataSrc 2 dropped",
+                    "AsyncDataSrc 1 dropped",
                 ]
             );
         }
@@ -1638,7 +1638,10 @@ mod tests_data_hub {
                     panic!();
                 }
 
-                assert!(hub.local_data_src_list.not_setup_head().is_null());
+                let mut ptr = hub.local_data_src_list.not_setup_head();
+                assert!(!ptr.is_null());
+                ptr = unsafe { (*ptr).next };
+                assert!(ptr.is_null());
                 let mut ptr = hub.local_data_src_list.did_setup_head();
                 assert!(!ptr.is_null());
                 ptr = unsafe { (*ptr).next };
@@ -1650,7 +1653,10 @@ mod tests_data_hub {
 
                 hub.end();
 
-                assert!(hub.local_data_src_list.not_setup_head().is_null());
+                let mut ptr = hub.local_data_src_list.not_setup_head();
+                assert!(!ptr.is_null());
+                ptr = unsafe { (*ptr).next };
+                assert!(ptr.is_null());
                 let mut ptr = hub.local_data_src_list.did_setup_head();
                 assert!(!ptr.is_null());
                 ptr = unsafe { (*ptr).next };
@@ -1703,7 +1709,10 @@ mod tests_data_hub {
                     panic!();
                 }
 
-                assert!(hub.local_data_src_list.not_setup_head().is_null());
+                let mut ptr = hub.local_data_src_list.not_setup_head();
+                assert!(!ptr.is_null());
+                ptr = unsafe { (*ptr).next };
+                assert!(ptr.is_null());
                 let mut ptr = hub.local_data_src_list.did_setup_head();
                 assert!(!ptr.is_null());
                 ptr = unsafe { (*ptr).next };
@@ -1715,7 +1724,10 @@ mod tests_data_hub {
 
                 hub.end();
 
-                assert!(hub.local_data_src_list.not_setup_head().is_null());
+                let mut ptr = hub.local_data_src_list.not_setup_head();
+                assert!(!ptr.is_null());
+                ptr = unsafe { (*ptr).next };
+                assert!(ptr.is_null());
                 let mut ptr = hub.local_data_src_list.did_setup_head();
                 assert!(!ptr.is_null());
                 ptr = unsafe { (*ptr).next };


### PR DESCRIPTION
This PR changes the error handling in `setup` function and `DataHub#begin` method. The current behavior is that the setup process executes `DataSrc#setup` methods of all registered `DataSrc`s even if some errors occur. The changed behavior is that the setup process stops immediately when an error occurs.