### PR TITLE
fix: changed inappropriate method names

### DIFF
--- a/src/data_hub.rs
+++ b/src/data_hub.rs
@@ -275,9 +275,9 @@ impl DataHub {
         self.data_src_map
             .retain(|nm, p| unsafe { !(*(*p)).local } || nm != name);
         self.local_data_src_list
-            .remove_and_drop_local_container_ptr_did_setup_by_name(name);
+            .remove_and_drop_container_ptr_did_setup_by_name(name);
         self.local_data_src_list
-            .remove_and_drop_local_container_ptr_not_setup_by_name(name);
+            .remove_and_drop_container_ptr_not_setup_by_name(name);
     }
 
     fn begin(&mut self) -> Result<(), Err> {

--- a/src/data_src.rs
+++ b/src/data_src.rs
@@ -150,14 +150,13 @@ impl DataSrcList {
         }
     }
 
-    pub(crate) fn remove_and_drop_local_container_ptr_not_setup_by_name(&mut self, name: &str) {
+    pub(crate) fn remove_and_drop_container_ptr_not_setup_by_name(&mut self, name: &str) {
         let mut ptr = self.not_setup_head;
         while !ptr.is_null() {
             let next = unsafe { (*ptr).next };
             let nm = unsafe { &(*ptr).name };
-            let local = unsafe { (*ptr).local };
 
-            if local && nm == name {
+            if nm == name {
                 let close_fn = unsafe { (*ptr).close_fn };
                 let drop_fn = unsafe { (*ptr).drop_fn };
 
@@ -212,14 +211,13 @@ impl DataSrcList {
         }
     }
 
-    pub(crate) fn remove_and_drop_local_container_ptr_did_setup_by_name(&mut self, name: &str) {
+    pub(crate) fn remove_and_drop_container_ptr_did_setup_by_name(&mut self, name: &str) {
         let mut ptr = self.did_setup_head;
         while !ptr.is_null() {
             let next = unsafe { (*ptr).next };
             let nm = unsafe { &(*ptr).name };
-            let local = unsafe { (*ptr).local };
 
-            if local && nm == name {
+            if nm == name {
                 let close_fn = unsafe { (*ptr).close_fn };
                 let drop_fn = unsafe { (*ptr).drop_fn };
 


### PR DESCRIPTION
This PR changes the following method names because whether a `DataSrcContainer` is local is determined by whether the `DataSrcList` that stores it is local.

- `remove_and_close_local_container_ptr_did_setup_by_name` -> `remove_and_close_container_ptr_did_setup_by_name`
- `remove_and_close_local_container_ptr_not_setup_by_name` -> `remove_and_close_container_ptr_not_setup_by_name`

The unit tests of those method is lack and I'll add them another PR.