### PR TITLE
new: enabled to use AsyncGroup in async functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ tokio = "1"
 [dev-dependencies]
 trybuild = "1"
 override_macro = "0.1"
+tokio = { version = "1", features = ["rt", "macros"] }

--- a/src/data_hub.rs
+++ b/src/data_hub.rs
@@ -318,7 +318,7 @@ impl DataHub {
             ptr = next;
         }
 
-        ag.join_and_put_errors_into(&mut err_map);
+        ag.join_and_collect_errors(&mut err_map);
 
         if !err_map.is_empty() {
             return Err(Err::new(DataHubError::FailToPreCommitDataConn {
@@ -344,7 +344,7 @@ impl DataHub {
             ptr = next;
         }
 
-        ag.join_and_put_errors_into(&mut err_map);
+        ag.join_and_collect_errors(&mut err_map);
 
         if !err_map.is_empty() {
             return Err(Err::new(DataHubError::FailToCommitDataConn {

--- a/src/data_src.rs
+++ b/src/data_src.rs
@@ -276,7 +276,7 @@ impl DataSrcList {
             ptr = next;
         }
 
-        ag.join_and_put_errors_into(&mut err_map);
+        ag.join_and_collect_errors(&mut err_map);
 
         let first_ptr_not_setup_yet = ptr;
 


### PR DESCRIPTION
This PR changes the method names for join and adds new methods for join in async functions.

- Changes the method name: `join_and_put_errors_into` --> `join_and_collect_errors`
- Add methods for join in async functions: `join_and_collect_errors_async`, `join_and_ignore_errors_async`