### PR TITLE
update!: changed the parameter of AsyncGroup#add from a closure to a future

### DIFF
--- a/src/data_hub.rs
+++ b/src/data_hub.rs
@@ -922,7 +922,7 @@ mod tests_data_hub {
             let logger = self.logger.clone();
             let id = self.id;
 
-            ag.add(async move || {
+            ag.add(async move {
                 // The `.await` must be executed outside the Mutex lock.
                 let _ = time::sleep(time::Duration::from_millis(100)).await;
 

--- a/src/data_src.rs
+++ b/src/data_src.rs
@@ -443,7 +443,7 @@ mod tests_of_data_src {
             let logger = self.logger.clone();
             let will_fail = self.will_fail;
             let id = self.id;
-            ag.add(async move || {
+            ag.add(async move {
                 let mut logger = logger.lock().unwrap();
                 if will_fail {
                     logger.push(format!("AsyncDataSrc {} failed to setup", id));


### PR DESCRIPTION
This PR changes the type of the parameter of `AsyncGroup#add` from a closure to a future.

The merits of changing to a future is:
1. Futures are slightly simpler to write than Closures
2. Futures have a slight performance advantage over Closures.
