### PR TITLE
update!: changed run/txn to macros, and changed the order of args of run/txn/run_async/txn_async

### DIFF
--- a/src/data_acc.rs
+++ b/src/data_acc.rs
@@ -48,8 +48,8 @@ impl DataAcc for DataHub {
 mod tests_of_data_acc {
     use super::*;
     use crate::data_hub::{clear_global_data_srcs_fixed, TEST_SEQ};
-    use crate::{run_async, setup_async, txn_async};
-    use crate::{setup, uses, AsyncGroup, DataHubError, DataSrc};
+    use crate::{run, run_async, setup, setup_async, txn, txn_async, uses};
+    use crate::{AsyncGroup, DataHubError, DataSrc};
     use override_macro::{overridable, override_with};
     use std::cell::RefCell;
     use std::rc::Rc;
@@ -342,9 +342,9 @@ mod tests_of_data_acc {
                 let result = setup();
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
+                let mut data = DataHub::new();
 
-                if let Err(_) = sample_logic(&mut hub) {
+                if let Err(_) = sample_logic(&mut data) {
                     panic!();
                 }
             }
@@ -384,9 +384,9 @@ mod tests_of_data_acc {
                 let result = setup_async().await;
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
+                let mut data = DataHub::new();
 
-                if let Err(_) = sample_logic_async(&mut hub).await {
+                if let Err(_) = sample_logic_async(&mut data).await {
                     panic!();
                 }
             }
@@ -474,8 +474,8 @@ mod tests_of_data_acc {
                 let result = setup();
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                assert!(hub.run(sample_logic).is_ok());
+                let mut data = DataHub::new();
+                assert!(run!(sample_logic, data).is_ok());
             }
 
             assert_eq!(
@@ -512,8 +512,8 @@ mod tests_of_data_acc {
                 let result = setup_async().await;
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                assert!(run_async!(hub, sample_logic_async).await.is_ok());
+                let mut data = DataHub::new();
+                assert!(run_async!(sample_logic_async, data).await.is_ok());
             }
 
             assert_eq!(
@@ -594,11 +594,11 @@ mod tests_of_data_acc {
             let logger = Arc::new(Mutex::new(Vec::new()));
             {
                 if let Ok(_auto_shutdown) = setup() {
-                    let mut hub = DataHub::new();
-                    hub.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), false));
-                    hub.uses("bar", BarDataSrc::new(2, logger.clone()));
+                    let mut data = DataHub::new();
+                    data.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), false));
+                    data.uses("bar", BarDataSrc::new(2, logger.clone()));
 
-                    assert!(hub.run(sample_logic).is_ok());
+                    assert!(run!(sample_logic, data).is_ok());
                 } else {
                     panic!();
                 }
@@ -635,11 +635,11 @@ mod tests_of_data_acc {
                 let result = setup();
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                hub.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), true));
-                hub.uses("bar", BarDataSrc::new(2, logger.clone()));
+                let mut data = DataHub::new();
+                data.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), true));
+                data.uses("bar", BarDataSrc::new(2, logger.clone()));
 
-                if let Err(err) = hub.run(sample_logic) {
+                if let Err(err) = run!(sample_logic, data) {
                     match err.reason::<DataHubError>() {
                         Ok(r) => match r {
                             DataHubError::FailToSetupLocalDataSrcs { errors } => {
@@ -680,11 +680,11 @@ mod tests_of_data_acc {
             let logger = Arc::new(Mutex::new(Vec::new()));
             {
                 if let Ok(_auto_shutdown) = setup_async().await {
-                    let mut hub = DataHub::new();
-                    hub.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), false));
-                    hub.uses("bar", BarDataSrc::new(2, logger.clone()));
+                    let mut data = DataHub::new();
+                    data.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), false));
+                    data.uses("bar", BarDataSrc::new(2, logger.clone()));
 
-                    assert!(run_async!(hub, sample_logic_async).await.is_ok());
+                    assert!(run_async!(sample_logic_async, data).await.is_ok());
                 } else {
                     panic!();
                 }
@@ -721,11 +721,11 @@ mod tests_of_data_acc {
                 let result = setup_async().await;
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                hub.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), true));
-                hub.uses("bar", BarDataSrc::new(2, logger.clone()));
+                let mut data = DataHub::new();
+                data.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), true));
+                data.uses("bar", BarDataSrc::new(2, logger.clone()));
 
-                if let Err(err) = run_async!(hub, sample_logic_async).await {
+                if let Err(err) = run_async!(sample_logic_async, data).await {
                     match err.reason::<DataHubError>() {
                         Ok(r) => match r {
                             DataHubError::FailToSetupLocalDataSrcs { errors } => {
@@ -818,10 +818,10 @@ mod tests_of_data_acc {
                 let result = setup();
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                hub.uses("foo", FooDataSrc::new(2, "Hello", logger.clone(), false));
+                let mut data = DataHub::new();
+                data.uses("foo", FooDataSrc::new(2, "Hello", logger.clone(), false));
 
-                assert!(hub.run(sample_logic).is_ok());
+                assert!(run!(sample_logic, data).is_ok());
             }
 
             assert_eq!(
@@ -856,10 +856,10 @@ mod tests_of_data_acc {
                 let result = setup_async().await;
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                hub.uses("foo", FooDataSrc::new(2, "Hello", logger.clone(), false));
+                let mut data = DataHub::new();
+                data.uses("foo", FooDataSrc::new(2, "Hello", logger.clone(), false));
 
-                assert!(run_async!(hub, sample_logic_async).await.is_ok());
+                assert!(run_async!(sample_logic_async, data).await.is_ok());
             }
 
             assert_eq!(
@@ -945,8 +945,8 @@ mod tests_of_data_acc {
                 let result = setup();
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                assert!(hub.txn(sample_logic).is_ok());
+                let mut data = DataHub::new();
+                assert!(txn!(sample_logic, data).is_ok());
             }
 
             assert_eq!(
@@ -989,8 +989,8 @@ mod tests_of_data_acc {
                 let result = setup_async().await;
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                assert!(txn_async!(hub, sample_logic_async).await.is_ok());
+                let mut data = DataHub::new();
+                assert!(txn_async!(sample_logic_async, data).await.is_ok());
             }
 
             assert_eq!(
@@ -1079,11 +1079,11 @@ mod tests_of_data_acc {
                 let result = setup();
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                hub.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), false));
-                hub.uses("bar", BarDataSrc::new(2, logger.clone()));
+                let mut data = DataHub::new();
+                data.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), false));
+                data.uses("bar", BarDataSrc::new(2, logger.clone()));
 
-                assert!(hub.txn(sample_logic).is_ok());
+                assert!(txn!(sample_logic, data).is_ok());
             }
 
             assert_eq!(
@@ -1123,11 +1123,11 @@ mod tests_of_data_acc {
                 let result = setup();
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                hub.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), true));
-                hub.uses("bar", BarDataSrc::new(2, logger.clone()));
+                let mut data = DataHub::new();
+                data.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), true));
+                data.uses("bar", BarDataSrc::new(2, logger.clone()));
 
-                if let Err(err) = hub.txn(sample_logic) {
+                if let Err(err) = txn!(sample_logic, data) {
                     match err.reason::<DataHubError>() {
                         Ok(r) => match r {
                             DataHubError::FailToSetupLocalDataSrcs { errors } => {
@@ -1174,11 +1174,11 @@ mod tests_of_data_acc {
                 let result = setup();
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                hub.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), false));
-                hub.uses("bar", BarDataSrc::new(2, logger.clone()));
+                let mut data = DataHub::new();
+                data.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), false));
+                data.uses("bar", BarDataSrc::new(2, logger.clone()));
 
-                if let Err(err) = hub.txn(failing_logic) {
+                if let Err(err) = txn!(failing_logic, data) {
                     match err.reason::<String>() {
                         Ok(s) => assert_eq!(s, "ZZZ"),
                         Err(_) => panic!(),
@@ -1212,11 +1212,11 @@ mod tests_of_data_acc {
                 let result = setup_async().await;
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                hub.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), false));
-                hub.uses("bar", BarDataSrc::new(2, logger.clone()));
+                let mut data = DataHub::new();
+                data.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), false));
+                data.uses("bar", BarDataSrc::new(2, logger.clone()));
 
-                assert!(txn_async!(hub, sample_logic_async).await.is_ok());
+                assert!(txn_async!(sample_logic_async, data).await.is_ok());
             }
 
             assert_eq!(
@@ -1256,11 +1256,11 @@ mod tests_of_data_acc {
                 let result = setup_async().await;
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                hub.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), true));
-                hub.uses("bar", BarDataSrc::new(2, logger.clone()));
+                let mut data = DataHub::new();
+                data.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), true));
+                data.uses("bar", BarDataSrc::new(2, logger.clone()));
 
-                if let Err(err) = txn_async!(hub, sample_logic_async).await {
+                if let Err(err) = txn_async!(sample_logic_async, data).await {
                     match err.reason::<DataHubError>() {
                         Ok(r) => match r {
                             DataHubError::FailToSetupLocalDataSrcs { errors } => {
@@ -1307,11 +1307,11 @@ mod tests_of_data_acc {
                 let result = setup_async().await;
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                hub.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), false));
-                hub.uses("bar", BarDataSrc::new(2, logger.clone()));
+                let mut data = DataHub::new();
+                data.uses("foo", FooDataSrc::new(1, "Hello", logger.clone(), false));
+                data.uses("bar", BarDataSrc::new(2, logger.clone()));
 
-                if let Err(err) = txn_async!(hub, failing_logic_async).await {
+                if let Err(err) = txn_async!(failing_logic_async, data).await {
                     match err.reason::<String>() {
                         Ok(s) => assert_eq!(s, "ZZZ"),
                         Err(_) => panic!(),
@@ -1396,10 +1396,10 @@ mod tests_of_data_acc {
                 let result = setup();
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                hub.uses("foo", FooDataSrc::new(2, "Hello", logger.clone(), false));
+                let mut data = DataHub::new();
+                data.uses("foo", FooDataSrc::new(2, "Hello", logger.clone(), false));
 
-                assert!(hub.txn(sample_logic).is_ok());
+                assert!(txn!(sample_logic, data).is_ok());
             }
 
             assert_eq!(
@@ -1441,10 +1441,10 @@ mod tests_of_data_acc {
                 let result = setup_async().await;
                 assert!(result.is_ok());
 
-                let mut hub = DataHub::new();
-                hub.uses("foo", FooDataSrc::new(2, "Hello", logger.clone(), false));
+                let mut data = DataHub::new();
+                data.uses("foo", FooDataSrc::new(2, "Hello", logger.clone(), false));
 
-                assert!(txn_async!(hub, sample_logic_async).await.is_ok());
+                assert!(txn_async!(sample_logic_async, data).await.is_ok());
             }
 
             assert_eq!(

--- a/src/data_hub.rs
+++ b/src/data_hub.rs
@@ -294,8 +294,8 @@ impl DataHub {
     ///
     /// This method is similar to the global `uses` function but registers a data source
     /// that is local to this specific `DataHub` session. Once the `DataHub`'s state is
-    /// "fixed" (while `run` or `txn` macro is executing), further calls
-    /// to `uses` are ignored. However, after `run` or `txn` completes, the `DataHub`'s
+    /// "fixed" (while `run!` or `txn!` macro is executing), further calls
+    /// to `uses` are ignored. However, after `run!` or `txn!` completes, the `DataHub`'s
     /// "fixed" state is reset, allowing for new data sources to be registered or removed
     /// via `disuses` method in subsequent operations.
     ///

--- a/src/data_hub.rs
+++ b/src/data_hub.rs
@@ -252,8 +252,6 @@ impl Drop for AutoShutdown {
 ///
 /// The `DataHub` is capable of performing aggregated transactional operations
 /// on all `DataConn` objects created from its registered `DataSrc` instances.
-/// The `run` method executes logic without transaction control, while the `txn`
-/// method executes logic within a controlled transaction.
 pub struct DataHub {
     local_data_src_list: DataSrcList,
     data_src_map: HashMap<String, *mut DataSrcContainer>,

--- a/src/data_hub.rs
+++ b/src/data_hub.rs
@@ -294,7 +294,7 @@ impl DataHub {
     ///
     /// This method is similar to the global `uses` function but registers a data source
     /// that is local to this specific `DataHub` session. Once the `DataHub`'s state is
-    /// "fixed" (while `run` or `txn` method is executing), further calls
+    /// "fixed" (while `run` or `txn` macro is executing), further calls
     /// to `uses` are ignored. However, after `run` or `txn` completes, the `DataHub`'s
     /// "fixed" state is reset, allowing for new data sources to be registered or removed
     /// via `disuses` method in subsequent operations.
@@ -336,7 +336,8 @@ impl DataHub {
             .remove_and_drop_container_ptr_not_setup_by_name(name);
     }
 
-    fn begin(&mut self) -> Result<(), Err> {
+    #[doc(hidden)]
+    pub fn begin(&mut self) -> Result<(), Err> {
         self.fixed = true;
 
         let err_map = self.local_data_src_list.setup_data_srcs();
@@ -371,7 +372,8 @@ impl DataHub {
         Ok(())
     }
 
-    fn commit(&mut self) -> Result<(), Err> {
+    #[doc(hidden)]
+    pub fn commit(&mut self) -> Result<(), Err> {
         let mut err_map = HashMap::new();
 
         let mut ag = AsyncGroup::new();
@@ -522,7 +524,8 @@ impl DataHub {
         return Ok(());
     }
 
-    fn rollback(&mut self) {
+    #[doc(hidden)]
+    pub fn rollback(&mut self) {
         let mut ag = AsyncGroup::new();
 
         let mut ptr = self.data_conn_list.head();
@@ -578,78 +581,6 @@ impl DataHub {
         self.data_conn_map.clear();
         self.data_conn_list.close_and_drop_data_conns();
         self.fixed = false;
-    }
-
-    /// Executes a given logic function without transaction control.
-    ///
-    /// This method sets up local data sources, runs the provided closure,
-    /// and then cleans up the `DataHub`'s session resources. It does not
-    /// perform commit or rollback operations.
-    ///
-    /// # Parameters
-    ///
-    /// * `logic_fn`: A closure that encapsulates the business logic to be executed.
-    ///   It takes a mutable reference to `DataHub` as an argument.
-    ///
-    /// # Returns
-    ///
-    /// * `Result<(), Err>`: The result of the logic function's execution,
-    ///   or an error if executing `logic_fn` fails.
-    pub fn run<F>(&mut self, logic_fn: F) -> Result<(), Err>
-    where
-        F: FnOnce(&mut DataHub) -> Result<(), Err> + Send + 'static,
-    {
-        let r = self.begin();
-        if r.is_err() {
-            self.end();
-            return r;
-        }
-
-        let r = logic_fn(self);
-        self.end();
-        r
-    }
-
-    /// Executes a given logic function within a transaction.
-    ///
-    /// This method first sets up local data sources, then runs the provided closure.
-    /// If the closure returns `Ok`, it attempts to commit all changes. If the commit fails,
-    /// or if the logic function itself returns an `Err`, a rollback operation
-    /// is performed. After succeeding `pre_commit` and `commit` methods of all `DataConn`s,
-    /// `post_commit` methods of all `DataConn`s are executed.
-    /// Finally, it cleans up the `DataHub`'s session resources.
-    ///
-    /// # Parameters
-    ///
-    /// * `logic_fn`: A closure that encapsulates the business logic to be executed.
-    ///   It takes a mutable reference to `DataHub` as an argument.
-    ///
-    /// # Returns
-    ///
-    /// * `Result<(), Err>`: The final result of the transaction (success or failure of
-    ///   logic/commit), or an error if executing `logic_fn` fails.
-    pub fn txn<F>(&mut self, logic_fn: F) -> Result<(), Err>
-    where
-        F: FnOnce(&mut DataHub) -> Result<(), Err> + Send + 'static,
-    {
-        let r = self.begin();
-        if r.is_err() {
-            self.end();
-            return r;
-        }
-
-        let mut r = logic_fn(self);
-
-        if r.is_ok() {
-            r = self.commit();
-        }
-
-        if r.is_err() {
-            self.rollback();
-        }
-
-        self.end();
-        r
     }
 
     /// Retrieves a mutable reference to a `DataConn` object by name, creating it if necessary.
@@ -744,6 +675,73 @@ impl Drop for DataHub {
     }
 }
 
+/// Executes a given logic function without transaction control.
+///
+/// This method sets up local data sources, runs the provided closure,
+/// and then cleans up the `DataHub`'s session resources. It does not
+/// perform commit or rollback operations.
+///
+/// # Parameters
+///
+/// * `logic_fn`: A closure that encapsulates the business logic to be executed.
+///   It takes a mutable reference to `DataHub` as an argument.
+/// * `hub`: A hub struct instance for data input/output operations.
+///
+/// # Returns
+///
+/// * `Result<(), Err>`: The result of the logic function's execution,
+///   or an error if executing `logic_fn` fails.
+#[macro_export]
+macro_rules! run {
+    ($logic_fn:expr, $hub:expr) => {{
+        let hub = &mut ($hub);
+        let mut r = hub.begin();
+        if r.is_ok() {
+            r = ($logic_fn)(hub);
+        }
+        hub.end();
+        r
+    }};
+}
+
+/// Executes a given logic function within a transaction.
+///
+/// This method first sets up local data sources, then runs the provided closure.
+/// If the closure returns `Ok`, it attempts to commit all changes. If the commit fails,
+/// or if the logic function itself returns an `Err`, a rollback operation
+/// is performed. After succeeding `pre_commit` and `commit` methods of all `DataConn`s,
+/// `post_commit` methods of all `DataConn`s are executed.
+/// Finally, it cleans up the `DataHub`'s session resources.
+///
+/// # Parameters
+///
+/// * `logic_fn`: A closure that encapsulates the business logic to be executed.
+///   It takes a mutable reference to `DataHub` as an argument.
+/// * `hub`: A hub struct instance for data input/output operations.
+///
+/// # Returns
+///
+/// * `Result<(), Err>`: The final result of the transaction (success or failure of
+///   logic/commit), or an error if executing `logic_fn` fails.
+#[macro_export]
+macro_rules! txn {
+    ($logic_fn:expr, $hub:expr) => {{
+        let hub = &mut ($hub);
+        let mut r = hub.begin();
+        if r.is_ok() {
+            r = ($logic_fn)(hub);
+        }
+        if r.is_ok() {
+            r = hub.commit();
+        }
+        if r.is_err() {
+            hub.rollback();
+        }
+        hub.end();
+        r
+    }};
+}
+
 /// Executes asynchronously a given logic function without transaction control.
 ///
 /// This macro sets up local data sources, runs the provided closure,
@@ -752,9 +750,9 @@ impl Drop for DataHub {
 ///
 /// # Parameters
 ///
-/// * `hub`: A hub struct instance for data input/output operations.
 /// * `logic_fn`: A closure that encapsulates the business logic to be executed.
 ///   It takes a mutable reference to `DataHub` as an argument.
+/// * `hub`: A hub struct instance for data input/output operations.
 ///
 /// # Returns
 ///
@@ -762,17 +760,13 @@ impl Drop for DataHub {
 ///   or an error if executing `logic_fn` fails.
 #[macro_export]
 macro_rules! run_async {
-    ($hub:expr, $logic_fn:expr) => {
+    ($logic_fn:expr, $hub:expr) => {
         async {
             let hub = &mut ($hub);
-
-            let r = hub.begin_async().await;
-            if r.is_err() {
-                hub.end();
-                return r;
+            let mut r = hub.begin_async().await;
+            if r.is_ok() {
+                r = ($logic_fn)(hub).await;
             }
-
-            let r = ($logic_fn)(hub).await;
             hub.end();
             r
         }
@@ -790,9 +784,9 @@ macro_rules! run_async {
 ///
 /// # Parameters
 ///
-/// * `hub`: A hub struct instance for data input/output operations.
 /// * `logic_fn`: A closure that encapsulates the business logic to be executed.
 ///   It takes a mutable reference to `DataHub` as an argument.
+/// * `hub`: A hub struct instance for data input/output operations.
 ///
 /// # Returns
 ///
@@ -800,26 +794,19 @@ macro_rules! run_async {
 ///   logic/commit), or an error if executing `logic_fn` fails.
 #[macro_export]
 macro_rules! txn_async {
-    ($hub:expr, $logic_fn:expr) => {
+    ($logic_fn:expr, $hub:expr) => {
         async {
             let hub = &mut ($hub);
-
-            let r = hub.begin_async().await;
-            if r.is_err() {
-                hub.end();
-                return r;
+            let mut r = hub.begin_async().await;
+            if r.is_ok() {
+                r = ($logic_fn)(hub).await;
             }
-
-            let mut r = ($logic_fn)(hub).await;
-
             if r.is_ok() {
                 r = hub.commit_async().await;
             }
-
             if r.is_err() {
                 hub.rollback_async().await;
             }
-
             hub.end();
             r
         }

--- a/src/data_hub.rs
+++ b/src/data_hub.rs
@@ -677,7 +677,7 @@ impl Drop for DataHub {
 
 /// Executes a given logic function without transaction control.
 ///
-/// This method sets up local data sources, runs the provided closure,
+/// This macro sets up local data sources, runs the provided closure,
 /// and then cleans up the `DataHub`'s session resources. It does not
 /// perform commit or rollback operations.
 ///
@@ -706,7 +706,7 @@ macro_rules! run {
 
 /// Executes a given logic function within a transaction.
 ///
-/// This method first sets up local data sources, then runs the provided closure.
+/// This macro first sets up local data sources, then runs the provided closure.
 /// If the closure returns `Ok`, it attempts to commit all changes. If the commit fails,
 /// or if the logic function itself returns an `Err`, a rollback operation
 /// is performed. After succeeding `pre_commit` and `commit` methods of all `DataConn`s,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! within the logic.
 //! You can execute logic functions with transaction control using the `txn!` macro,
 //! or without transaction control using the `run!` macro.
-//! Futhermore, you can execute asynchronous logic function with transaction control using
+//! Furthermore, you can execute asynchronous logic function with transaction control using
 //! `txn_async!` macro or without transaction control using the `run_async!` macro.
 //!
 //! This framework brings clear separation and robustness to Rust application design.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,11 @@
 //!
 //! Furthermore, the `DataHub` provides transaction control for data operations performed
 //! within the logic.
-//! You can execute logic functions with transaction control using the `DataHub#txn` method,
-//! or without it using the `DataHub#run` method.
+//! You can execute logic functions with transaction control using the `txn!` macro,
+//! or without transaction control using the `run!` macro.
+//! Futhermore, you can execute asynchronous logic function with transaction control using
+//! `txn_async!` macro or without transaction control using the `run_async!` macro.
+//!
 //! This framework brings clear separation and robustness to Rust application design.
 //!
 //! ## Example
@@ -29,7 +32,7 @@
 //! The following is a sample code using this framework:
 //!
 //! ```rust
-//! use sabi::{uses, setup, AsyncGroup, DataSrc, DataConn, DataAcc, DataHub};
+//! use sabi::{AsyncGroup, DataSrc, DataConn, DataAcc, DataHub};
 //! use errs::Err;
 //! use override_macro::{overridable, override_with};
 //!
@@ -121,11 +124,11 @@
 //!
 //! fn main() {
 //!     // Register global DataSrc.
-//!     uses("foo", FooDataSrc{});
+//!     sabi::uses("foo", FooDataSrc{});
 //!     // Set up the sabi framework.
 //!     // _auto_shutdown automatically closes and drops global DataSrc at the end of the scope.
 //!     // NOTE: Don't write as `let _ = ...` because the return variable is dropped immediately.
-//!     let _auto_shutdown = setup().unwrap();
+//!     let _auto_shutdown = sabi::setup().unwrap();
 //!
 //!     // Create a new instance of DataHub.
 //!     let mut data = DataHub::new();
@@ -134,7 +137,7 @@
 //!
 //!     // Execute application logic within a transaction.
 //!     // my_logic performs data operations via DataHub.
-//!     let _ = data.txn(my_logic).unwrap();
+//!     let _ = sabi::txn!(my_logic, data).unwrap();
 //! }
 //! ```
 //!
@@ -152,11 +155,11 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     // Register global DataSrc.
-//!     uses("foo", FooDataSrc{}).await;
+//!     sabi::uses("foo", FooDataSrc{}).await;
 //!     // Set up the sabi framework.
 //!     // _auto_shutdown automatically closes and drops global DataSrc at the end of the scope.
 //!     // NOTE: Don't write as `let _ = ...` because the return variable is dropped immediately.
-//!     let _auto_shutdown = setup_async().await.unwrap();
+//!     let _auto_shutdown = sabi::setup_async().await.unwrap();
 //!
 //!     // Create a new instance of DataHub.
 //!     let mut data = DataHub::new();
@@ -165,7 +168,7 @@
 //!
 //!     // Execute application logic within a transaction.
 //!     // my_logic performs data operations via DataHub.
-//!     let _ = txn_async!(data, my_logic).await.unwrap();
+//!     let _ = sabi::txn_async!(my_logic, data).await.unwrap();
 //! }
 //! ```
 


### PR DESCRIPTION
This PR changes `DataHub#run` and `DataHub#txn` into the macros `run!` and `txn!`, respectively.
The purpose of this change is to align the syntax for both synchronous processing (`run`, `txn`) and asynchronous processing (`run_async`, `txn_async`).

Additionally, along with the already-macro-ized `run_async` and `txn_async`, the order of their arguments will be changed to `(logic_fn, data)`.
The reason for this change is that the meaning of `run!`, for example, is "run `logic_fn` with `data`," so I believe it is more natural to align the argument order to `run!(logic_fn, data)`.

Closes #61