### PR TITLE
chore: chore: added msrv task in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,6 +51,13 @@ doc() {
   errcheck $?
 }
 
+msrv() {
+  cargo update
+  errcheck $?
+  cargo msrv find
+  errcheck $?
+}
+
 if [[ "$#" == "0" ]]; then
   #clean
   format
@@ -86,8 +93,8 @@ else
     bench)
       bench
       ;;
-    '')
-      compile
+    msrv)
+      msrv
       ;;
     *)
       echo "Bad task: $a"


### PR DESCRIPTION
This PR adds `msrv` task in `build.sh`.

While `cargo-msrv` is a tool that finds the Minimum Supported Rust Version, it won't find the correct minimum version unless we run `cargo update` to update `Cargo.lock` beforehand.

Therefore, I've added a task to `build.sh` that runs `cargo update` and `cargo msrv` together.