### PR TITLE
fix: made `new` function public and added `join` method of AsyncGroup

### DIFF
--- a/src/async_group.rs
+++ b/src/async_group.rs
@@ -16,7 +16,8 @@ pub enum AsyncGroupError {
 }
 
 impl AsyncGroup {
-    pub(crate) fn new() -> Self {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
         Self {
             handlers: Vec::new(),
             _name: "".into(),
@@ -43,7 +44,7 @@ impl AsyncGroup {
         self.handlers.push((self._name.clone(), thread::spawn(f)));
     }
 
-    pub(crate) fn join_and_collect_errors(&mut self, errors: &mut Vec<(Arc<str>, errs::Err)>) {
+    pub(crate) fn join_and_collect_errors(mut self, errors: &mut Vec<(Arc<str>, errs::Err)>) {
         if self.handlers.is_empty() {
             return;
         }
@@ -69,7 +70,7 @@ impl AsyncGroup {
         }
     }
 
-    pub(crate) fn join_and_ignore_errors(&mut self) {
+    pub(crate) fn join_and_ignore_errors(mut self) {
         if self.handlers.is_empty() {
             return;
         }
@@ -79,6 +80,13 @@ impl AsyncGroup {
         for h in vec.into_iter() {
             let _ = h.1.join();
         }
+    }
+
+    #[inline]
+    pub fn join(self) -> Vec<(Arc<str>, errs::Err)> {
+        let mut vec = Vec::new();
+        self.join_and_collect_errors(&mut vec);
+        vec
     }
 }
 
@@ -159,7 +167,7 @@ mod tests_of_async_group {
 
         #[test]
         fn zero() {
-            let mut ag = AsyncGroup::new();
+            let ag = AsyncGroup::new();
 
             let mut err_vec = Vec::new();
             ag.join_and_collect_errors(&mut err_vec);
@@ -422,7 +430,7 @@ mod tests_of_async_group {
 
         #[test]
         fn zero() {
-            let mut ag = AsyncGroup::new();
+            let ag = AsyncGroup::new();
 
             ag.join_and_ignore_errors();
         }

--- a/src/tokio/async_group.rs
+++ b/src/tokio/async_group.rs
@@ -9,7 +9,8 @@ use std::future::Future;
 use std::sync::Arc;
 
 impl AsyncGroup {
-    pub(crate) fn new() -> Self {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
         Self {
             tasks: Vec::new(),
             names: Vec::new(),
@@ -52,6 +53,13 @@ impl AsyncGroup {
 
     pub(crate) async fn join_and_ignore_errors_async(self) {
         let _ = future::join_all(self.tasks).await;
+    }
+
+    #[inline]
+    pub async fn join_async(self) -> Vec<(Arc<str>, errs::Err)> {
+        let mut vec = Vec::new();
+        self.join_and_collect_errors_async(&mut vec).await;
+        vec
     }
 }
 

--- a/tests/async_group_tests.rs
+++ b/tests/async_group_tests.rs
@@ -1,0 +1,72 @@
+#[cfg(test)]
+mod test_on_std {
+    use sabi::AsyncGroup;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn test_ok() {
+        let flag = Arc::new(Mutex::new(false));
+        assert_eq!(*flag.lock().unwrap(), false);
+
+        let mut ag = AsyncGroup::new();
+        let flag_clone = flag.clone();
+        ag.add(move || {
+            let mut f = flag_clone.lock().unwrap();
+            *f = true;
+            Ok(())
+        });
+        let vec = ag.join();
+
+        assert_eq!(vec.len(), 0);
+        assert_eq!(*flag.lock().unwrap(), true);
+    }
+
+    #[test]
+    fn test_err() {
+        let mut ag = AsyncGroup::new();
+        ag.add(|| Err(errs::Err::new("bad")));
+        let vec = ag.join();
+
+        assert_eq!(vec.len(), 1);
+        assert_eq!(vec[0].0, "".into());
+        assert_eq!(*vec[0].1.reason::<&str>().unwrap(), "bad");
+    }
+}
+
+#[cfg(feature = "tokio")]
+#[cfg(test)]
+mod test_on_tokio {
+    use sabi::tokio::AsyncGroup;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    #[tokio::test]
+    async fn test_ok() {
+        let flag = Arc::new(Mutex::new(false));
+        assert_eq!(*flag.lock().await, false);
+
+        let flag_clone = flag.clone();
+
+        let mut ag = AsyncGroup::new();
+        ag.add(async move {
+            let mut f = flag_clone.lock().await;
+            *f = true;
+            Ok(())
+        });
+        let vec = ag.join_async().await;
+
+        assert_eq!(vec.len(), 0);
+        assert_eq!(*flag.lock().await, true);
+    }
+
+    #[tokio::test]
+    async fn test_err() {
+        let mut ag = AsyncGroup::new();
+        ag.add(async { Err(errs::Err::new("bad")) });
+        let vec = ag.join_async().await;
+
+        assert_eq!(vec.len(), 1);
+        assert_eq!(vec[0].0, "".into());
+        assert_eq!(*vec[0].1.reason::<&str>().unwrap(), "bad");
+    }
+}


### PR DESCRIPTION
This PR changes the accessibility of the `new` function to public, and adds a new `join` method of `AsyncGroup` to allow users to instantiate and manipulate this struct. This changes are intended to enable users to test methods in `DataSrc` and `DataConn` that take an `AsyncGroup` as an argument.
