### PR TITLE
fix: corrected the downcast target from fmt::Debug to &str or String in AsyncGroup

### DIFF
--- a/src/async_group.rs
+++ b/src/async_group.rs
@@ -5,7 +5,7 @@
 use crate::AsyncGroup;
 
 use std::sync::Arc;
-use std::{fmt, mem, thread};
+use std::{mem, thread};
 
 /// The enum type representing the reasons for errors that can occur within an [`AsyncGroup`].
 #[derive(Debug)]
@@ -59,9 +59,12 @@ impl AsyncGroup {
                     }
                 }
                 Err(e) => {
-                    let s = match e.downcast_ref::<Box<dyn fmt::Debug>>() {
-                        Some(d) => format!("{d:?}"),
-                        None => "".to_string(),
+                    let s = if let Some(s) = e.downcast_ref::<&'static str>() {
+                        s.to_string()
+                    } else if let Some(s) = e.downcast_ref::<String>() {
+                        s.clone()
+                    } else {
+                        "Unknown panic payload".to_string()
                     };
                     let e = errs::Err::new(AsyncGroupError::ThreadPanicked(s));
                     errors.push((h.0.clone(), e));


### PR DESCRIPTION
This PR updates the panic payload extraction logic to explicitly handle `&'static str` and `String` types.

Previously, the code attempted to downcast the payload to `Box<dyn fmt::Debug>`, which is not the standard way panic messages are stored in Rust. By directly downcasting to common string types, we can more reliably capture and display the actual panic message.

### Changes
Removed the attempt to downcast the panic payload to `Box<dyn fmt::Debug>`.
Added explicit downcasting for:
- `&'static str`: Common for literal panic messages like `panic!("error")`.
- `String`: Common for formatted panic messages like `panic!("error: {}", code)`.

Added a fallback string `"Unknown panic payload"` for cases where the payload is of an unexpected type.

### Impact
This change ensures that panic messages are correctly captured and logged/reported, improving the observability of failures.