### PR TITLE
update: changed _name field of AsyncGroup to _index

### DIFF
--- a/src/async_group.rs
+++ b/src/async_group.rs
@@ -4,7 +4,6 @@
 
 use crate::AsyncGroup;
 
-use std::sync::Arc;
 use std::{mem, thread};
 
 /// The enum type representing the reasons for errors that can occur within an [`AsyncGroup`].
@@ -20,7 +19,7 @@ impl AsyncGroup {
     pub fn new() -> Self {
         Self {
             handlers: Vec::new(),
-            _name: "".into(),
+            _index: 0,
         }
     }
 
@@ -41,10 +40,10 @@ impl AsyncGroup {
     where
         F: FnOnce() -> errs::Result<()> + Send + 'static,
     {
-        self.handlers.push((self._name.clone(), thread::spawn(f)));
+        self.handlers.push((self._index, thread::spawn(f)));
     }
 
-    pub(crate) fn join_and_collect_errors(mut self, errors: &mut Vec<(Arc<str>, errs::Err)>) {
+    pub(crate) fn join_and_collect_errors(mut self, errors: &mut Vec<(usize, errs::Err)>) {
         if self.handlers.is_empty() {
             return;
         }
@@ -55,7 +54,7 @@ impl AsyncGroup {
             match h.1.join() {
                 Ok(r) => {
                     if let Err(e) = r {
-                        errors.push((h.0.clone(), e));
+                        errors.push((h.0, e));
                     }
                 }
                 Err(e) => {
@@ -67,7 +66,7 @@ impl AsyncGroup {
                         "Unknown panic payload".to_string()
                     };
                     let e = errs::Err::new(AsyncGroupError::ThreadPanicked(s));
-                    errors.push((h.0.clone(), e));
+                    errors.push((h.0, e));
                 }
             }
         }
@@ -86,7 +85,7 @@ impl AsyncGroup {
     }
 
     #[inline]
-    pub fn join(self) -> Vec<(Arc<str>, errs::Err)> {
+    pub fn join(self) -> Vec<(usize, errs::Err)> {
         let mut vec = Vec::new();
         self.join_and_collect_errors(&mut vec);
         vec
@@ -185,7 +184,7 @@ mod tests_of_async_group {
             let struct_a = MyStruct::new("a".to_string(), false);
             assert_eq!(*struct_a.string.lock().unwrap(), "a");
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
             let mut errors = Vec::new();
@@ -202,7 +201,7 @@ mod tests_of_async_group {
             let struct_a = MyStruct::new("a".to_string(), true);
             assert_eq!(*struct_a.string.lock().unwrap(), "a");
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
             let mut errors = Vec::new();
@@ -211,7 +210,7 @@ mod tests_of_async_group {
             assert_eq!(errors.len(), 1);
             assert_eq!(*struct_a.string.lock().unwrap(), "a");
 
-            assert_eq!(errors[0].0, "foo".into());
+            assert_eq!(errors[0].0, 12);
             #[cfg(unix)]
             assert_eq!(
                 format!("{:?}", errors[0].1),
@@ -237,13 +236,13 @@ mod tests_of_async_group {
             let struct_c = MyStruct::new("c".to_string(), false);
             assert_eq!(*struct_c.string.lock().unwrap(), "c".to_string());
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
-            ag._name = "bar".into();
+            ag._index = 34;
             struct_b.process(&mut ag);
 
-            ag._name = "baz".into();
+            ag._index = 56;
             struct_c.process(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -269,20 +268,20 @@ mod tests_of_async_group {
             let struct_c = MyStruct::new("c".to_string(), false);
             assert_eq!(*struct_c.string.lock().unwrap(), "c");
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
-            ag._name = "bar".into();
+            ag._index = 34;
             struct_b.process(&mut ag);
 
-            ag._name = "baz".into();
+            ag._index = 56;
             struct_c.process(&mut ag);
 
             let mut err_vec = Vec::new();
             ag.join_and_collect_errors(&mut err_vec);
 
             assert_eq!(err_vec.len(), 1);
-            assert_eq!(err_vec[0].0, "bar".into());
+            assert_eq!(err_vec[0].0, 34);
             #[cfg(unix)]
             assert_eq!(
                 format!("{:?}", err_vec[0].1),
@@ -312,13 +311,13 @@ mod tests_of_async_group {
             let struct_c = MyStruct::new("c".to_string(), true);
             assert_eq!(*struct_c.string.lock().unwrap(), "c");
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
-            ag._name = "bar".into();
+            ag._index = 34;
             struct_b.process(&mut ag);
 
-            ag._name = "baz".into();
+            ag._index = 56;
             struct_c.process(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -326,9 +325,9 @@ mod tests_of_async_group {
 
             assert_eq!(err_vec.len(), 3);
 
-            assert_eq!(err_vec[0].0, "foo".into());
-            assert_eq!(err_vec[1].0, "bar".into());
-            assert_eq!(err_vec[2].0, "baz".into());
+            assert_eq!(err_vec[0].0, 12);
+            assert_eq!(err_vec[1].0, 34);
+            assert_eq!(err_vec[2].0, 56);
 
             #[cfg(unix)]
             assert_eq!(
@@ -373,7 +372,7 @@ mod tests_of_async_group {
             let struct_d = MyStruct::new("d".to_string(), false);
             assert_eq!(*struct_d.string.lock().unwrap(), "d");
 
-            ag._name = "foo".into();
+            ag._index = 123;
             struct_d.process(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -391,7 +390,7 @@ mod tests_of_async_group {
             let struct_d = MyStruct::new("d".to_string(), true);
             assert_eq!(*struct_d.string.lock().unwrap(), "d");
 
-            ag._name = "foo".into();
+            ag._index = 123;
             struct_d.process_multiple(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -399,8 +398,8 @@ mod tests_of_async_group {
 
             assert_eq!(err_vec.len(), 2);
 
-            assert_eq!(err_vec[0].0, "foo".into());
-            assert_eq!(err_vec[1].0, "foo".into());
+            assert_eq!(err_vec[0].0, 123);
+            assert_eq!(err_vec[1].0, 123);
 
             #[cfg(unix)]
             assert_eq!(
@@ -445,7 +444,7 @@ mod tests_of_async_group {
             let struct_a = MyStruct::new("a".to_string(), false);
             assert_eq!(*struct_a.string.lock().unwrap(), "a");
 
-            ag._name = "foo".into();
+            ag._index = 123;
             struct_a.process(&mut ag);
 
             ag.join_and_ignore_errors();
@@ -459,7 +458,7 @@ mod tests_of_async_group {
             let struct_a = MyStruct::new("a".to_string(), true);
             assert_eq!(*struct_a.string.lock().unwrap(), "a");
 
-            ag._name = "foo".into();
+            ag._index = 123;
             struct_a.process(&mut ag);
 
             ag.join_and_ignore_errors();
@@ -479,13 +478,13 @@ mod tests_of_async_group {
             let struct_c = MyStruct::new("c".to_string(), false);
             assert_eq!(*struct_c.string.lock().unwrap(), "c");
 
-            ag._name = "foo".into();
+            ag._index = 123;
             struct_a.process(&mut ag);
 
-            ag._name = "bar".into();
+            ag._index = 456;
             struct_b.process(&mut ag);
 
-            ag._name = "baz".into();
+            ag._index = 789;
             struct_c.process(&mut ag);
 
             ag.join_and_ignore_errors();
@@ -508,13 +507,13 @@ mod tests_of_async_group {
             let struct_c = MyStruct::new("c".to_string(), false);
             assert_eq!(*struct_c.string.lock().unwrap(), "c");
 
-            ag._name = "foo".into();
+            ag._index = 123;
             struct_a.process(&mut ag);
 
-            ag._name = "bar".into();
+            ag._index = 456;
             struct_b.process(&mut ag);
 
-            ag._name = "baz".into();
+            ag._index = 789;
             struct_c.process(&mut ag);
 
             ag.join_and_ignore_errors();
@@ -537,13 +536,13 @@ mod tests_of_async_group {
             let struct_c = MyStruct::new("c".to_string(), true);
             assert_eq!(*struct_c.string.lock().unwrap(), "c");
 
-            ag._name = "foo".into();
+            ag._index = 123;
             struct_a.process(&mut ag);
 
-            ag._name = "bar".into();
+            ag._index = 456;
             struct_b.process(&mut ag);
 
-            ag._name = "baz".into();
+            ag._index = 789;
             struct_c.process(&mut ag);
 
             ag.join_and_ignore_errors();

--- a/src/data_conn.rs
+++ b/src/data_conn.rs
@@ -192,6 +192,23 @@ impl DataConnManager {
         None
     }
 
+    fn indexed_errors_to_named_errors(
+        &self,
+        indexed_errors: Vec<(usize, errs::Err)>,
+    ) -> Vec<(Arc<str>, errs::Err)> {
+        let mut ret_vec = Vec::new();
+
+        for (i, err) in indexed_errors.into_iter() {
+            if let Some(ssnnptr) = &self.vec[i] {
+                let ptr = ssnnptr.non_null_ptr.as_ptr();
+                let name = unsafe { (*ptr).name.clone() };
+                ret_vec.push((name, err));
+            }
+        }
+
+        ret_vec
+    }
+
     pub(crate) fn to_typed_ptr<C>(
         ssnnptr: &SendSyncNonNull<DataConnContainer>,
     ) -> errs::Result<*mut DataConnContainer<C>>
@@ -218,12 +235,12 @@ impl DataConnManager {
         let mut errors = Vec::new();
 
         let mut ag = AsyncGroup::new();
-        for ssnnptr in self.vec.iter().flatten() {
+        for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let pre_commit_fn = unsafe { (*ptr).pre_commit_fn };
-            ag._name = unsafe { (*ptr).name.clone() };
+            ag._index = i;
             if let Err(err) = pre_commit_fn(ptr, &mut ag) {
-                errors.push((ag._name.clone(), err));
+                errors.push((ag._index, err));
                 break;
             }
         }
@@ -231,17 +248,17 @@ impl DataConnManager {
 
         if !errors.is_empty() {
             return Err(errs::Err::new(DataConnError::FailToPreCommitDataConn {
-                errors,
+                errors: self.indexed_errors_to_named_errors(errors),
             }));
         }
 
         let mut ag = AsyncGroup::new();
-        for ssnnptr in self.vec.iter().flatten() {
+        for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let commit_fn = unsafe { (*ptr).commit_fn };
-            ag._name = unsafe { (*ptr).name.clone() };
+            ag._index = i;
             if let Err(err) = commit_fn(ptr, &mut ag) {
-                errors.push((ag._name.clone(), err));
+                errors.push((ag._index, err));
                 break;
             }
         }
@@ -249,15 +266,15 @@ impl DataConnManager {
 
         if !errors.is_empty() {
             return Err(errs::Err::new(DataConnError::FailToCommitDataConn {
-                errors,
+                errors: self.indexed_errors_to_named_errors(errors),
             }));
         }
 
         let mut ag = AsyncGroup::new();
-        for ssnnptr in self.vec.iter().flatten() {
+        for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let post_commit_fn = unsafe { (*ptr).post_commit_fn };
-            ag._name = unsafe { (*ptr).name.clone() };
+            ag._index = i;
             post_commit_fn(ptr, &mut ag);
         }
         ag.join_and_ignore_errors();
@@ -267,12 +284,12 @@ impl DataConnManager {
 
     pub(crate) fn rollback(&mut self) {
         let mut ag = AsyncGroup::new();
-        for ssnnptr in self.vec.iter().flatten() {
+        for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let should_force_back_fn = unsafe { (*ptr).should_force_back_fn };
             let force_back_fn = unsafe { (*ptr).force_back_fn };
             let rollback_fn = unsafe { (*ptr).rollback_fn };
-            ag._name = unsafe { (*ptr).name.clone() };
+            ag._index = i;
 
             if should_force_back_fn(ptr) {
                 force_back_fn(ptr, &mut ag);

--- a/src/data_src/mod.rs
+++ b/src/data_src/mod.rs
@@ -210,23 +210,32 @@ impl DataSrcManager {
             return;
         }
 
+        let mut indexed_errors = Vec::<(usize, errs::Err)>::new();
+
         let mut n_done = 0;
         let mut ag = AsyncGroup::new();
-        for ssnnptr in self.vec_unready.iter() {
+        for (i, ssnnptr) in self.vec_unready.iter().enumerate() {
             n_done += 1;
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let setup_fn = unsafe { (*ptr).setup_fn };
-            ag._name = unsafe { (*ptr).name.clone() };
+            ag._index = i;
             if let Err(err) = setup_fn(ptr, &mut ag) {
-                errors.push((ag._name.clone(), err));
+                indexed_errors.push((ag._index, err));
                 break;
             }
         }
-        ag.join_and_collect_errors(errors);
+        ag.join_and_collect_errors(&mut indexed_errors);
 
-        if errors.is_empty() {
+        if indexed_errors.is_empty() {
             self.vec_ready.append(&mut self.vec_unready);
         } else {
+            for (i, err) in indexed_errors.into_iter() {
+                let ssnnptr = &self.vec_unready[i];
+                let ptr = ssnnptr.non_null_ptr.as_ptr();
+                let name = unsafe { (*ptr).name.clone() };
+                errors.push((name, err));
+            }
+
             for ssnnptr in self.vec_unready[0..n_done].iter().rev() {
                 let ptr = ssnnptr.non_null_ptr.as_ptr();
                 let close_fn = unsafe { (*ptr).close_fn };
@@ -264,27 +273,37 @@ impl DataSrcManager {
             }
         }
 
+        let mut indexed_errors = Vec::<(usize, errs::Err)>::new();
+
         let mut n_done = 0;
         let mut ag = AsyncGroup::new();
-        for ssnnptr_opt in ordered_vec.iter() {
+        for (i, ssnnptr_opt) in ordered_vec.iter().enumerate() {
             n_done += 1;
             if let Some(ssnnptr) = ssnnptr_opt {
                 let ptr = ssnnptr.non_null_ptr.as_ptr();
                 let setup_fn = unsafe { (*ptr).setup_fn };
-                ag._name = unsafe { (*ptr).name.clone() };
+                ag._index = i;
                 if let Err(err) = setup_fn(ptr, &mut ag) {
-                    errors.push((ag._name.clone(), err));
+                    indexed_errors.push((ag._index, err));
                     break;
                 }
             }
         }
-        ag.join_and_collect_errors(errors);
+        ag.join_and_collect_errors(&mut indexed_errors);
 
-        if errors.is_empty() {
+        if indexed_errors.is_empty() {
             for ssnnptr in ordered_vec.into_iter().flatten() {
                 self.vec_ready.push(ssnnptr);
             }
         } else {
+            for (i, err) in indexed_errors.into_iter() {
+                if let Some(ssnnptr) = &ordered_vec[i] {
+                    let ptr = ssnnptr.non_null_ptr.as_ptr();
+                    let name = unsafe { (*ptr).name.clone() };
+                    errors.push((name, err));
+                }
+            }
+
             for ssnnptr in ordered_vec[0..n_done].iter().flatten().rev() {
                 let ptr = ssnnptr.non_null_ptr.as_ptr();
                 let close_fn = unsafe { (*ptr).close_fn };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,8 @@ pub mod tokio;
 /// and can collect any errors that occur.
 /// This structure implements `Send` and `Sync`.
 pub struct AsyncGroup {
-    handlers: Vec<(Arc<str>, thread::JoinHandle<errs::Result<()>>)>,
-    pub(crate) _name: Arc<str>,
+    handlers: Vec<(usize, thread::JoinHandle<errs::Result<()>>)>,
+    _index: usize,
 }
 
 /// The trait that abstracts a connection per session to an external data service,

--- a/src/tokio/async_group.rs
+++ b/src/tokio/async_group.rs
@@ -6,15 +6,14 @@ use super::AsyncGroup;
 
 use futures::future;
 use std::future::Future;
-use std::sync::Arc;
 
 impl AsyncGroup {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
             tasks: Vec::new(),
-            names: Vec::new(),
-            _name: "".into(),
+            indexes: Vec::new(),
+            _index: 0,
         }
     }
 
@@ -32,13 +31,10 @@ impl AsyncGroup {
         Fut: Future<Output = errs::Result<()>> + Send + 'static,
     {
         self.tasks.push(Box::pin(future));
-        self.names.push(self._name.clone());
+        self.indexes.push(self._index);
     }
 
-    pub(crate) async fn join_and_collect_errors_async(
-        self,
-        errors: &mut Vec<(Arc<str>, errs::Err)>,
-    ) {
+    pub(crate) async fn join_and_collect_errors_async(self, errors: &mut Vec<(usize, errs::Err)>) {
         if self.tasks.is_empty() {
             return;
         }
@@ -46,7 +42,7 @@ impl AsyncGroup {
         let result_all = future::join_all(self.tasks).await;
         for (i, result) in result_all.into_iter().enumerate() {
             if let Err(err) = result {
-                errors.push((self.names[i].clone(), err));
+                errors.push((self.indexes[i], err));
             }
         }
     }
@@ -56,7 +52,7 @@ impl AsyncGroup {
     }
 
     #[inline]
-    pub async fn join_async(self) -> Vec<(Arc<str>, errs::Err)> {
+    pub async fn join_async(self) -> Vec<(usize, errs::Err)> {
         let mut vec = Vec::new();
         self.join_and_collect_errors_async(&mut vec).await;
         vec
@@ -166,7 +162,7 @@ mod tests_of_async_group {
             let struct_a = MyStruct::new("a".to_string(), false);
             assert_eq!(*struct_a.string.lock().await, "a");
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
             let mut errors = Vec::new();
@@ -183,7 +179,7 @@ mod tests_of_async_group {
             let struct_a = MyStruct::new("a".to_string(), true);
             assert_eq!(*struct_a.string.lock().await, "a");
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
             let mut errors = Vec::new();
@@ -192,7 +188,7 @@ mod tests_of_async_group {
             assert_eq!(errors.len(), 1);
             assert_eq!(*struct_a.string.lock().await, "a");
 
-            assert_eq!(errors[0].0, "foo".into());
+            assert_eq!(errors[0].0, 12);
             #[cfg(unix)]
             assert_eq!(
                 format!("{:?}", errors[0].1),
@@ -218,13 +214,13 @@ mod tests_of_async_group {
             let struct_c = MyStruct::new("c".to_string(), false);
             assert_eq!(*struct_c.string.lock().await, "c".to_string());
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
-            ag._name = "bar".into();
+            ag._index = 34;
             struct_b.process(&mut ag);
 
-            ag._name = "baz".into();
+            ag._index = 56;
             struct_c.process(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -250,20 +246,20 @@ mod tests_of_async_group {
             let struct_c = MyStruct::new("c".to_string(), false);
             assert_eq!(*struct_c.string.lock().await, "c");
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
-            ag._name = "bar".into();
+            ag._index = 34;
             struct_b.process(&mut ag);
 
-            ag._name = "baz".into();
+            ag._index = 56;
             struct_c.process(&mut ag);
 
             let mut err_vec = Vec::new();
             ag.join_and_collect_errors_async(&mut err_vec).await;
 
             assert_eq!(err_vec.len(), 1);
-            assert_eq!(err_vec[0].0, "bar".into());
+            assert_eq!(err_vec[0].0, 34);
             #[cfg(unix)]
             assert_eq!(
                 format!("{:?}", err_vec[0].1),
@@ -293,13 +289,13 @@ mod tests_of_async_group {
             let struct_c = MyStruct::new("c".to_string(), true);
             assert_eq!(*struct_c.string.lock().await, "c");
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
-            ag._name = "bar".into();
+            ag._index = 34;
             struct_b.process(&mut ag);
 
-            ag._name = "baz".into();
+            ag._index = 56;
             struct_c.process(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -307,9 +303,9 @@ mod tests_of_async_group {
 
             assert_eq!(err_vec.len(), 3);
 
-            assert_eq!(err_vec[0].0, "foo".into());
-            assert_eq!(err_vec[1].0, "bar".into());
-            assert_eq!(err_vec[2].0, "baz".into());
+            assert_eq!(err_vec[0].0, 12);
+            assert_eq!(err_vec[1].0, 34);
+            assert_eq!(err_vec[2].0, 56);
 
             #[cfg(unix)]
             assert_eq!(
@@ -354,7 +350,7 @@ mod tests_of_async_group {
             let struct_d = MyStruct::new("d".to_string(), false);
             assert_eq!(*struct_d.string.lock().await, "d");
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_d.process(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -372,7 +368,7 @@ mod tests_of_async_group {
             let struct_d = MyStruct::new("d".to_string(), true);
             assert_eq!(*struct_d.string.lock().await, "d");
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_d.process_multiple(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -380,8 +376,8 @@ mod tests_of_async_group {
 
             assert_eq!(err_vec.len(), 2);
 
-            assert_eq!(err_vec[0].0, "foo".into());
-            assert_eq!(err_vec[1].0, "foo".into());
+            assert_eq!(err_vec[0].0, 12);
+            assert_eq!(err_vec[1].0, 12);
 
             #[cfg(unix)]
             assert_eq!(
@@ -426,7 +422,7 @@ mod tests_of_async_group {
             let struct_a = MyStruct::new("a".to_string(), false);
             assert_eq!(*struct_a.string.lock().await, "a".to_string());
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
             ag.join_and_ignore_errors_async().await;
@@ -440,7 +436,7 @@ mod tests_of_async_group {
             let struct_a = MyStruct::new("a".to_string(), true);
             assert_eq!(*struct_a.string.lock().await, "a".to_string());
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
             ag.join_and_ignore_errors_async().await;
@@ -460,13 +456,13 @@ mod tests_of_async_group {
             let struct_c = MyStruct::new("c".to_string(), false);
             assert_eq!(*struct_c.string.lock().await, "c".to_string());
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
-            ag._name = "bar".into();
+            ag._index = 34;
             struct_b.process(&mut ag);
 
-            ag._name = "baz".into();
+            ag._index = 56;
             struct_c.process(&mut ag);
 
             ag.join_and_ignore_errors_async().await;
@@ -489,13 +485,13 @@ mod tests_of_async_group {
             let struct_c = MyStruct::new("c".to_string(), false);
             assert_eq!(*struct_c.string.lock().await, "c".to_string());
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
-            ag._name = "bar".into();
+            ag._index = 34;
             struct_b.process(&mut ag);
 
-            ag._name = "baz".into();
+            ag._index = 56;
             struct_c.process(&mut ag);
 
             ag.join_and_ignore_errors_async().await;
@@ -518,13 +514,13 @@ mod tests_of_async_group {
             let struct_c = MyStruct::new("c".to_string(), true);
             assert_eq!(*struct_c.string.lock().await, "c".to_string());
 
-            ag._name = "foo".into();
+            ag._index = 12;
             struct_a.process(&mut ag);
 
-            ag._name = "bar".into();
+            ag._index = 34;
             struct_b.process(&mut ag);
 
-            ag._name = "baz".into();
+            ag._index = 56;
             struct_c.process(&mut ag);
 
             ag.join_and_ignore_errors_async().await;

--- a/src/tokio/data_conn.rs
+++ b/src/tokio/data_conn.rs
@@ -195,6 +195,23 @@ impl DataConnManager {
         None
     }
 
+    fn index_errors_to_named_errors(
+        &self,
+        indexed_errors: Vec<(usize, errs::Err)>,
+    ) -> Vec<(Arc<str>, errs::Err)> {
+        let mut ret_vec = Vec::new();
+
+        for (i, err) in indexed_errors.into_iter() {
+            if let Some(ssnnptr) = &self.vec[i] {
+                let ptr = ssnnptr.non_null_ptr.as_ptr();
+                let name = unsafe { (*ptr).name.clone() };
+                ret_vec.push((name, err));
+            }
+        }
+
+        ret_vec
+    }
+
     pub(crate) fn to_typed_ptr<C>(
         ssnnptr: &SendSyncNonNull<DataConnContainer>,
     ) -> errs::Result<*mut DataConnContainer<C>>
@@ -218,49 +235,49 @@ impl DataConnManager {
     }
 
     pub(crate) async fn commit_async(&self) -> errs::Result<()> {
-        let mut errors = Vec::new();
+        let mut indexed_errors = Vec::new();
 
         let mut ag = AsyncGroup::new();
-        for ssnnptr in self.vec.iter().flatten() {
+        for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let pre_commit_fn = unsafe { (*ptr).pre_commit_fn };
-            ag._name = unsafe { (*ptr).name.clone() };
+            ag._index = i;
             if let Err(err) = pre_commit_fn(ptr, &mut ag).await {
-                errors.push((ag._name.clone(), err));
+                indexed_errors.push((ag._index, err));
                 break;
             }
         }
-        ag.join_and_collect_errors_async(&mut errors).await;
+        ag.join_and_collect_errors_async(&mut indexed_errors).await;
 
-        if !errors.is_empty() {
+        if !indexed_errors.is_empty() {
             return Err(errs::Err::new(DataConnError::FailToPreCommitDataConn {
-                errors,
+                errors: self.index_errors_to_named_errors(indexed_errors),
             }));
         }
 
         let mut ag = AsyncGroup::new();
-        for ssnnptr in self.vec.iter().flatten() {
+        for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let commit_fn = unsafe { (*ptr).commit_fn };
-            ag._name = unsafe { (*ptr).name.clone() };
+            ag._index = i;
             if let Err(err) = commit_fn(ptr, &mut ag).await {
-                errors.push((ag._name.clone(), err));
+                indexed_errors.push((ag._index, err));
                 break;
             }
         }
-        ag.join_and_collect_errors_async(&mut errors).await;
+        ag.join_and_collect_errors_async(&mut indexed_errors).await;
 
-        if !errors.is_empty() {
+        if !indexed_errors.is_empty() {
             return Err(errs::Err::new(DataConnError::FailToCommitDataConn {
-                errors,
+                errors: self.index_errors_to_named_errors(indexed_errors),
             }));
         }
 
         let mut ag = AsyncGroup::new();
-        for ssnnptr in self.vec.iter().flatten() {
+        for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let post_commit_fn = unsafe { (*ptr).post_commit_fn };
-            ag._name = unsafe { (*ptr).name.clone() };
+            ag._index = i;
             post_commit_fn(ptr, &mut ag).await;
         }
         ag.join_and_ignore_errors_async().await;
@@ -270,12 +287,12 @@ impl DataConnManager {
 
     pub(crate) async fn rollback_async(&mut self) {
         let mut ag = AsyncGroup::new();
-        for ssnnptr in self.vec.iter().flatten() {
+        for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let should_force_back_fn = unsafe { (*ptr).should_force_back_fn };
             let force_back_fn = unsafe { (*ptr).force_back_fn };
             let rollback_fn = unsafe { (*ptr).rollback_fn };
-            ag._name = unsafe { (*ptr).name.clone() };
+            ag._index = i;
 
             if should_force_back_fn(ptr) {
                 force_back_fn(ptr, &mut ag).await;

--- a/src/tokio/data_src/mod.rs
+++ b/src/tokio/data_src/mod.rs
@@ -223,23 +223,32 @@ impl DataSrcManager {
             return;
         }
 
+        let mut indexed_errors = Vec::<(usize, errs::Err)>::new();
+
         let mut n_done = 0;
         let mut ag = AsyncGroup::new();
-        for ssnnptr in self.vec_unready.iter() {
+        for (i, ssnnptr) in self.vec_unready.iter().enumerate() {
             n_done += 1;
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let setup_fn = unsafe { (*ptr).setup_fn };
-            ag._name = unsafe { (*ptr).name.clone() };
+            ag._index = i;
             if let Err(err) = setup_fn(ptr, &mut ag).await {
-                errors.push((ag._name.clone(), err));
+                indexed_errors.push((ag._index, err));
                 break;
             }
         }
-        ag.join_and_collect_errors_async(errors).await;
+        ag.join_and_collect_errors_async(&mut indexed_errors).await;
 
-        if errors.is_empty() {
+        if indexed_errors.is_empty() {
             self.vec_ready.append(&mut self.vec_unready);
         } else {
+            for (i, err) in indexed_errors.into_iter() {
+                let ssnnptr = &self.vec_unready[i];
+                let ptr = ssnnptr.non_null_ptr.as_ptr();
+                let name = unsafe { (*ptr).name.clone() };
+                errors.push((name, err));
+            }
+
             for ssnnptr in self.vec_unready[0..n_done].iter().rev() {
                 let ptr = ssnnptr.non_null_ptr.as_ptr();
                 let close_fn = unsafe { (*ptr).close_fn };
@@ -277,27 +286,37 @@ impl DataSrcManager {
             }
         }
 
+        let mut indexed_errors = Vec::<(usize, errs::Err)>::new();
+
         let mut n_done = 0;
         let mut ag = AsyncGroup::new();
-        for ssnnptr_opt in ordered_vec.iter() {
+        for (i, ssnnptr_opt) in ordered_vec.iter().enumerate() {
             n_done += 1;
             if let Some(ssnnptr) = ssnnptr_opt {
                 let ptr = ssnnptr.non_null_ptr.as_ptr();
                 let setup_fn = unsafe { (*ptr).setup_fn };
-                ag._name = unsafe { (*ptr).name.clone() };
+                ag._index = i;
                 if let Err(err) = setup_fn(ptr, &mut ag).await {
-                    errors.push((ag._name.clone(), err));
+                    indexed_errors.push((ag._index, err));
                     break;
                 }
             }
         }
-        ag.join_and_collect_errors_async(errors).await;
+        ag.join_and_collect_errors_async(&mut indexed_errors).await;
 
-        if errors.is_empty() {
+        if indexed_errors.is_empty() {
             for ssnnptr in ordered_vec.into_iter().flatten() {
                 self.vec_ready.push(ssnnptr);
             }
         } else {
+            for (i, err) in indexed_errors.into_iter() {
+                if let Some(ssnnptr) = &ordered_vec[i] {
+                    let ptr = ssnnptr.non_null_ptr.as_ptr();
+                    let name = unsafe { (*ptr).name.clone() };
+                    errors.push((name, err));
+                }
+            }
+
             for ssnnptr in ordered_vec[0..n_done].iter().flatten().rev() {
                 let ptr = ssnnptr.non_null_ptr.as_ptr();
                 let close_fn = unsafe { (*ptr).close_fn };

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -73,9 +73,9 @@ pub use crate::_uses_for_async as uses;
 /// and their results (or errors) collected.
 #[allow(clippy::type_complexity)]
 pub struct AsyncGroup {
-    names: Vec<Arc<str>>,
+    indexes: Vec<usize>,
     tasks: Vec<Pin<Box<dyn Future<Output = errs::Result<()>> + Send + 'static>>>,
-    pub(crate) _name: Arc<str>,
+    _index: usize,
 }
 
 /// A trait for data connection implementations, providing methods for transaction management.

--- a/tests/async_group_tests.rs
+++ b/tests/async_group_tests.rs
@@ -28,7 +28,7 @@ mod test_on_std {
         let vec = ag.join();
 
         assert_eq!(vec.len(), 1);
-        assert_eq!(vec[0].0, "".into());
+        assert_eq!(vec[0].0, 0);
         assert_eq!(*vec[0].1.reason::<&str>().unwrap(), "bad");
     }
 }
@@ -66,7 +66,7 @@ mod test_on_tokio {
         let vec = ag.join_async().await;
 
         assert_eq!(vec.len(), 1);
-        assert_eq!(vec[0].0, "".into());
+        assert_eq!(vec[0].0, 0);
         assert_eq!(*vec[0].1.reason::<&str>().unwrap(), "bad");
     }
 }


### PR DESCRIPTION
This PR changes the `_name: Arc<str>` field in `AsyncGroup` to `_index: usize`.

Using `_name` posed an issue because if duplicate names existed within the `DataSrc` or `DataConn` lists, it was impossible to uniquely identify a specific instance by its name.

With the introduction of `DataConn#on_txn_failure`, we now need to invoke `on_txn_failure` for all `DataConn` instances—not just the one where the error occurred. This hook must pass whether a commit failure occurred, a rollback failure occurred, or if the connection succeeded but was affected by a failure in another service. To support this requirement, we switched to using the list index (`_index`) to ensure each connection can be uniquely identified.