### PR TITLE
update!: removed force_back and added on_txn_failure of DataConn

### DIFF
--- a/src/data_acc.rs
+++ b/src/data_acc.rs
@@ -13,7 +13,7 @@ impl DataAcc for DataHub {
 #[cfg(test)]
 mod tests_of_data_acc {
     use super::*;
-    use crate::{AsyncGroup, DataSrc};
+    use crate::{AsyncGroup, DataSrc, TxnFailureReport};
     use std::cell::RefCell;
     use std::rc::Rc;
     use std::sync::{Arc, Mutex};
@@ -62,18 +62,20 @@ mod tests_of_data_acc {
             logger.push(format!("FooDataConn::pre_commit {}", self.id));
             Ok(())
         }
-        fn post_commit(&mut self, _ag: &mut AsyncGroup) {
+        fn post_commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             let mut logger = self.logger.lock().unwrap();
             logger.push(format!("FooDataConn::post_commit {}", self.id));
+            Ok(())
         }
-        fn should_force_back(&self) -> bool {
+        fn is_committed(&self) -> bool {
             self.committed
         }
-        fn rollback(&mut self, _ag: &mut AsyncGroup) {
+        fn rollback(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             let mut logger = self.logger.lock().unwrap();
             logger.push(format!("FooDataConn::rollback {}", self.id));
+            Ok(())
         }
-        fn force_back(&mut self, _ag: &mut AsyncGroup) {
+        fn on_txn_failure(&mut self, _ag: &mut AsyncGroup, _reports: &[TxnFailureReport]) {
             let mut logger = self.logger.lock().unwrap();
             logger.push(format!("FooDataConn::force_back {}", self.id));
         }
@@ -193,18 +195,20 @@ mod tests_of_data_acc {
             logger.push(format!("BarDataConn::pre_commit {}", self.id));
             Ok(())
         }
-        fn post_commit(&mut self, _ag: &mut AsyncGroup) {
+        fn post_commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             let mut logger = self.logger.lock().unwrap();
             logger.push(format!("BarDataConn::post_commit {}", self.id));
+            Ok(())
         }
-        fn should_force_back(&self) -> bool {
+        fn is_committed(&self) -> bool {
             self.committed
         }
-        fn rollback(&mut self, _ag: &mut AsyncGroup) {
+        fn rollback(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             let mut logger = self.logger.lock().unwrap();
             logger.push(format!("BarDataConn::rollback {}", self.id));
+            Ok(())
         }
-        fn force_back(&mut self, _ag: &mut AsyncGroup) {
+        fn on_txn_failure(&mut self, _ag: &mut AsyncGroup, _reports: &[TxnFailureReport]) {
             let mut logger = self.logger.lock().unwrap();
             logger.push(format!("BarDataConn::force_back {}", self.id));
         }

--- a/src/data_conn.rs
+++ b/src/data_conn.rs
@@ -2,7 +2,10 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-use crate::{AsyncGroup, DataConn, DataConnContainer, DataConnManager, SendSyncNonNull};
+use crate::{
+    AsyncGroup, DataConn, DataConnContainer, DataConnManager, SendSyncNonNull, TxnFailureCause,
+    TxnFailureReport, TxnFailureRollback,
+};
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -28,6 +31,14 @@ pub enum DataConnError {
         errors: Vec<(Arc<str>, errs::Err)>,
     },
 
+    /// Indicates a failure during the post-commit process of one or more [`DataConn`] instances
+    /// involved in a transaction.
+    /// Contains a vector of data connection names and their corresponding errors.
+    FailToPostCommitDataConn {
+        /// The vector contains errors that occurred in each [`DataConn`] object.
+        errors: Vec<(Arc<str>, errs::Err)>,
+    },
+
     /// Indicates a failure to cast a retrieved [`DataConn`] to the expected type.
     FailToCastDataConn {
         /// The name of the data connection that failed to cast.
@@ -46,12 +57,13 @@ where
         Self {
             drop_fn: drop_data_conn::<C>,
             is_fn: is_data_conn::<C>,
+            type_fn: type_of_data_conn::<C>,
             commit_fn: commit_data_conn::<C>,
             pre_commit_fn: pre_commit_data_conn::<C>,
             post_commit_fn: post_commit_data_conn::<C>,
-            should_force_back_fn: should_force_back_data_conn::<C>,
+            is_committed_fn: is_committed_data_conn::<C>,
             rollback_fn: rollback_data_conn::<C>,
-            force_back_fn: force_back_data_conn::<C>,
+            on_txn_failure_fn: on_txn_failure_data_conn::<C>,
             close_fn: close_data_conn::<C>,
 
             name: name.into(),
@@ -77,6 +89,13 @@ where
     any::TypeId::of::<C>() == type_id
 }
 
+fn type_of_data_conn<C>() -> &'static str
+where
+    C: DataConn + 'static,
+{
+    any::type_name::<C>()
+}
+
 fn commit_data_conn<C>(ptr: *const DataConnContainer, ag: &mut AsyncGroup) -> errs::Result<()>
 where
     C: DataConn + 'static,
@@ -93,41 +112,40 @@ where
     unsafe { (*typed_ptr).data_conn.pre_commit(ag) }
 }
 
-fn post_commit_data_conn<C>(ptr: *const DataConnContainer, ag: &mut AsyncGroup)
+fn post_commit_data_conn<C>(ptr: *const DataConnContainer, ag: &mut AsyncGroup) -> errs::Result<()>
 where
+    C: DataConn + 'static,
+{
+    let typed_ptr = ptr as *mut DataConnContainer<C>;
+    unsafe { (*typed_ptr).data_conn.post_commit(ag) }
+}
+
+fn is_committed_data_conn<C>(ptr: *const DataConnContainer) -> bool
+where
+    C: DataConn + 'static,
+{
+    let typed_ptr = ptr as *mut DataConnContainer<C>;
+    unsafe { (*typed_ptr).data_conn.is_committed() }
+}
+
+fn rollback_data_conn<C>(ptr: *const DataConnContainer, ag: &mut AsyncGroup) -> errs::Result<()>
+where
+    C: DataConn + 'static,
+{
+    let typed_ptr = ptr as *mut DataConnContainer<C>;
+    unsafe { (*typed_ptr).data_conn.rollback(ag) }
+}
+
+fn on_txn_failure_data_conn<C>(
+    ptr: *const DataConnContainer,
+    ag: &mut AsyncGroup,
+    reports: &[TxnFailureReport],
+) where
     C: DataConn + 'static,
 {
     let typed_ptr = ptr as *mut DataConnContainer<C>;
     unsafe {
-        (*typed_ptr).data_conn.post_commit(ag);
-    }
-}
-
-fn should_force_back_data_conn<C>(ptr: *const DataConnContainer) -> bool
-where
-    C: DataConn + 'static,
-{
-    let typed_ptr = ptr as *mut DataConnContainer<C>;
-    unsafe { (*typed_ptr).data_conn.should_force_back() }
-}
-
-fn rollback_data_conn<C>(ptr: *const DataConnContainer, ag: &mut AsyncGroup)
-where
-    C: DataConn + 'static,
-{
-    let typed_ptr = ptr as *mut DataConnContainer<C>;
-    unsafe {
-        (*typed_ptr).data_conn.rollback(ag);
-    }
-}
-
-fn force_back_data_conn<C>(ptr: *const DataConnContainer, ag: &mut AsyncGroup)
-where
-    C: DataConn + 'static,
-{
-    let typed_ptr = ptr as *mut DataConnContainer<C>;
-    unsafe {
-        (*typed_ptr).data_conn.force_back(ag);
+        (*typed_ptr).data_conn.on_txn_failure(ag, reports);
     }
 }
 
@@ -192,23 +210,6 @@ impl DataConnManager {
         None
     }
 
-    fn indexed_errors_to_named_errors(
-        &self,
-        indexed_errors: Vec<(usize, errs::Err)>,
-    ) -> Vec<(Arc<str>, errs::Err)> {
-        let mut ret_vec = Vec::new();
-
-        for (i, err) in indexed_errors.into_iter() {
-            if let Some(ssnnptr) = &self.vec[i] {
-                let ptr = ssnnptr.non_null_ptr.as_ptr();
-                let name = unsafe { (*ptr).name.clone() };
-                ret_vec.push((name, err));
-            }
-        }
-
-        ret_vec
-    }
-
     pub(crate) fn to_typed_ptr<C>(
         ssnnptr: &SendSyncNonNull<DataConnContainer>,
     ) -> errs::Result<*mut DataConnContainer<C>>
@@ -231,8 +232,20 @@ impl DataConnManager {
         Ok(typed_ptr)
     }
 
-    pub(crate) fn commit(&self) -> errs::Result<()> {
-        let mut errors = Vec::new();
+    pub(crate) fn new_failure_reports(&self) -> Vec<TxnFailureReport> {
+        let mut reports = Vec::new();
+        for ssnnptr in self.vec.iter().flatten() {
+            let ptr = ssnnptr.non_null_ptr.as_ptr();
+            let name = unsafe { (*ptr).name.clone() };
+            let type_fn = unsafe { (*ptr).type_fn };
+            let report = TxnFailureReport::new(name, type_fn());
+            reports.push(report);
+        }
+        reports
+    }
+
+    pub(crate) fn commit(&self, reports: &mut [TxnFailureReport]) -> errs::Result<()> {
+        let mut indexed_errors = Vec::new();
 
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
@@ -240,33 +253,51 @@ impl DataConnManager {
             let pre_commit_fn = unsafe { (*ptr).pre_commit_fn };
             ag._index = i;
             if let Err(err) = pre_commit_fn(ptr, &mut ag) {
-                errors.push((ag._index, err));
+                indexed_errors.push((ag._index, err));
                 break;
             }
         }
-        ag.join_and_collect_errors(&mut errors);
+        ag.join_and_collect_errors(&mut indexed_errors);
 
-        if !errors.is_empty() {
+        if !indexed_errors.is_empty() {
+            let mut errors = Vec::new();
+            for (i, err) in indexed_errors.into_iter() {
+                let report = &mut reports[i];
+                report.cause = TxnFailureCause::RunFailure(err.clone());
+                errors.push((report.data_conn_name.clone(), err));
+            }
             return Err(errs::Err::new(DataConnError::FailToPreCommitDataConn {
-                errors: self.indexed_errors_to_named_errors(errors),
+                errors,
             }));
         }
 
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
+            let is_committed_fn = unsafe { (*ptr).is_committed_fn };
+            if is_committed_fn(ptr) {
+                // Set this alongside the committed state by PreCommit, during the rollback process
+                //report.cause = TxnFailureCause::NoneByCommitted;
+                continue;
+            }
             let commit_fn = unsafe { (*ptr).commit_fn };
             ag._index = i;
             if let Err(err) = commit_fn(ptr, &mut ag) {
-                errors.push((ag._index, err));
+                indexed_errors.push((ag._index, err));
                 break;
             }
         }
-        ag.join_and_collect_errors(&mut errors);
+        ag.join_and_collect_errors(&mut indexed_errors);
 
-        if !errors.is_empty() {
+        if !indexed_errors.is_empty() {
+            let mut errors = Vec::new();
+            for (i, err) in indexed_errors.into_iter() {
+                let report = &mut reports[i];
+                report.cause = TxnFailureCause::CommitFailure(err.clone());
+                errors.push((report.data_conn_name.clone(), err));
+            }
             return Err(errs::Err::new(DataConnError::FailToCommitDataConn {
-                errors: self.indexed_errors_to_named_errors(errors),
+                errors,
             }));
         }
 
@@ -275,27 +306,64 @@ impl DataConnManager {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let post_commit_fn = unsafe { (*ptr).post_commit_fn };
             ag._index = i;
-            post_commit_fn(ptr, &mut ag);
+            if let Err(err) = post_commit_fn(ptr, &mut ag) {
+                indexed_errors.push((ag._index, err));
+                // don't break;
+            }
         }
-        ag.join_and_ignore_errors();
+        ag.join_and_collect_errors(&mut indexed_errors);
+
+        if !indexed_errors.is_empty() {
+            let mut errors = Vec::new();
+            for (i, err) in indexed_errors.into_iter() {
+                let report = &mut reports[i];
+                report.cause = TxnFailureCause::PostCommitFailure(err.clone());
+                errors.push((report.data_conn_name.clone(), err));
+            }
+            return Err(errs::Err::new(DataConnError::FailToPostCommitDataConn {
+                errors,
+            }));
+        }
 
         Ok(())
     }
 
-    pub(crate) fn rollback(&mut self) {
+    pub(crate) fn rollback(&mut self, mut reports: Vec<TxnFailureReport>) {
+        let mut indexed_errors = Vec::new();
+
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
-            let should_force_back_fn = unsafe { (*ptr).should_force_back_fn };
-            let force_back_fn = unsafe { (*ptr).force_back_fn };
+            let report = &mut reports[i];
+            let is_committed_fn = unsafe { (*ptr).is_committed_fn };
+            if is_committed_fn(ptr) {
+                if let TxnFailureCause::NoneByUncommitted = report.cause {
+                    report.cause = TxnFailureCause::NoneByCommitted;
+                }
+                continue;
+            }
             let rollback_fn = unsafe { (*ptr).rollback_fn };
             ag._index = i;
-
-            if should_force_back_fn(ptr) {
-                force_back_fn(ptr, &mut ag);
+            if let Err(err) = rollback_fn(ptr, &mut ag) {
+                indexed_errors.push((ag._index, err));
             } else {
-                rollback_fn(ptr, &mut ag);
+                report.rollback = TxnFailureRollback::Success;
             }
+        }
+        ag.join_and_collect_errors(&mut indexed_errors);
+
+        if !indexed_errors.is_empty() {
+            for (i, err) in indexed_errors.into_iter() {
+                let report = &mut reports[i];
+                report.rollback = TxnFailureRollback::Failure(err);
+            }
+        }
+
+        let mut ag = AsyncGroup::new();
+        for ssnnptr in self.vec.iter().flatten() {
+            let ptr = ssnnptr.non_null_ptr.as_ptr();
+            let on_txn_failure_fn = unsafe { (*ptr).on_txn_failure_fn };
+            on_txn_failure_fn(ptr, &mut ag, &reports);
         }
         ag.join_and_ignore_errors();
     }
@@ -304,7 +372,6 @@ impl DataConnManager {
         self.index_map.clear();
 
         let vec: Vec<Option<SendSyncNonNull<DataConnContainer>>> = mem::take(&mut self.vec);
-
         for ssnnptr in vec.iter().flatten() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let close_fn = unsafe { (*ptr).close_fn };
@@ -330,11 +397,16 @@ mod tests_of_data_conn {
     };
     use std::{ptr, thread, time};
 
+    const BASE_LINE: u32 = line!();
+
     #[derive(PartialEq, Copy, Clone)]
     enum Fail {
         Not,
         Commit,
         PreCommit,
+        PostCommit,
+        Rollback,
+        PreCommitBecomeCommitted,
     }
 
     struct SyncDataConn {
@@ -393,28 +465,46 @@ mod tests_of_data_conn {
                 .lock()
                 .unwrap()
                 .push(format!("SyncDataConn::pre_commit {}", self.id));
+            if self.fail == Fail::PreCommitBecomeCommitted {
+                self.committed = true;
+            }
             Ok(())
         }
-        fn post_commit(&mut self, _ag: &mut AsyncGroup) {
+        fn post_commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+            if self.fail == Fail::PostCommit {
+                self.logger
+                    .lock()
+                    .unwrap()
+                    .push(format!("SyncDataConn::post_commit {} failed", self.id));
+                return Err(errs::Err::new("!!!".to_string()));
+            }
             self.logger
                 .lock()
                 .unwrap()
                 .push(format!("SyncDataConn::post_commit {}", self.id));
+            Ok(())
         }
-        fn should_force_back(&self) -> bool {
+        fn is_committed(&self) -> bool {
             self.committed
         }
-        fn rollback(&mut self, _ag: &mut AsyncGroup) {
+        fn rollback(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+            if self.fail == Fail::Rollback {
+                self.logger
+                    .lock()
+                    .unwrap()
+                    .push(format!("SyncDataConn::rollback {} failed", self.id));
+                return Err(errs::Err::new("???".to_string()));
+            }
             self.logger
                 .lock()
                 .unwrap()
                 .push(format!("SyncDataConn::rollback {}", self.id));
+            Ok(())
         }
-        fn force_back(&mut self, _ag: &mut AsyncGroup) {
-            self.logger
-                .lock()
-                .unwrap()
-                .push(format!("SyncDataConn::force_back {}", self.id));
+        fn on_txn_failure(&mut self, _ag: &mut AsyncGroup, reports: &[TxnFailureReport]) {
+            let mut logger = self.logger.lock().unwrap();
+            logger.push(format!("SyncDataConn::on_txn_failure {}", self.id));
+            logger.push(format!("TxnFailureReports={:?}", reports));
         }
         fn close(&mut self) {
             self.logger
@@ -480,6 +570,7 @@ mod tests_of_data_conn {
             let fail = self.fail;
             let logger = self.logger.clone();
             let id = self.id;
+            let committed = self.committed.clone();
             ag.add(move || {
                 thread::sleep(time::Duration::from_millis(100));
                 if fail == Fail::PreCommit {
@@ -489,6 +580,9 @@ mod tests_of_data_conn {
                         .push(format!("AsyncDataConn::pre_commit {} failed", id));
                     return Err(errs::Err::new("yyy".to_string()));
                 }
+                if fail == Fail::PreCommitBecomeCommitted {
+                    committed.store(true, Ordering::Release);
+                }
                 logger
                     .lock()
                     .unwrap()
@@ -497,42 +591,60 @@ mod tests_of_data_conn {
             });
             Ok(())
         }
-        fn post_commit(&mut self, ag: &mut AsyncGroup) {
+        fn post_commit(&mut self, ag: &mut AsyncGroup) -> errs::Result<()> {
             let logger = self.logger.clone();
             let id = self.id;
+            let fail = self.fail;
             ag.add(move || {
                 thread::sleep(time::Duration::from_millis(100));
+                if fail == Fail::PostCommit {
+                    logger
+                        .lock()
+                        .unwrap()
+                        .push(format!("AsyncDataConn::post_commit {} failed", id));
+                    return Err(errs::Err::new("!!!".to_string()));
+                }
                 logger
                     .lock()
                     .unwrap()
                     .push(format!("AsyncDataConn::post_commit {}", id));
                 Ok(())
             });
+            Ok(())
         }
-        fn should_force_back(&self) -> bool {
+        fn is_committed(&self) -> bool {
             self.committed.load(Ordering::Acquire)
         }
-        fn rollback(&mut self, ag: &mut AsyncGroup) {
+        fn rollback(&mut self, ag: &mut AsyncGroup) -> errs::Result<()> {
             let logger = self.logger.clone();
+            let fail = self.fail;
             let id = self.id;
             ag.add(move || {
                 thread::sleep(time::Duration::from_millis(100));
+                if fail == Fail::Rollback {
+                    logger
+                        .lock()
+                        .unwrap()
+                        .push(format!("AsyncDataConn::rollback {} failed", id));
+                    return Err(errs::Err::new("???".to_string()));
+                }
                 logger
                     .lock()
                     .unwrap()
                     .push(format!("AsyncDataConn::rollback {}", id));
                 Ok(())
             });
+            Ok(())
         }
-        fn force_back(&mut self, ag: &mut AsyncGroup) {
+        fn on_txn_failure(&mut self, ag: &mut AsyncGroup, reports: &[TxnFailureReport]) {
+            let reports_log = format!("TxnFailureReports={:?}", reports);
             let logger = self.logger.clone();
             let id = self.id;
             ag.add(move || {
                 thread::sleep(time::Duration::from_millis(100));
-                logger
-                    .lock()
-                    .unwrap()
-                    .push(format!("AsyncDataConn::force_back {}", id));
+                let mut logger = logger.lock().unwrap();
+                logger.push(format!("AsyncDataConn::on_txn_failure {}", id));
+                logger.push(reports_log);
                 Ok(())
             });
         }
@@ -767,7 +879,46 @@ mod tests_of_data_conn {
         }
 
         #[test]
-        fn test_commit_ok() {
+        fn test_new_failure_reports() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            let mut manager = DataConnManager::new();
+
+            let vec = manager.new_failure_reports();
+            assert_eq!(vec.len(), 0);
+
+            let conn = SyncDataConn::new(1, logger.clone(), Fail::Not);
+            let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+            let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+            let ssnnptr = SendSyncNonNull::new(nnptr);
+            manager.add(ssnnptr);
+
+            let conn = AsyncDataConn::new(2, logger.clone(), Fail::Not);
+            let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+            let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+            let ssnnptr = SendSyncNonNull::new(nnptr);
+            manager.add(ssnnptr);
+
+            let vec = manager.new_failure_reports();
+            assert_eq!(vec.len(), 2);
+
+            let report = &vec[0];
+            assert_eq!(report.data_conn_name, "foo".into());
+            assert_eq!(
+                report.data_conn_type,
+                "sabi::data_conn::tests_of_data_conn::SyncDataConn"
+            );
+
+            let report = &vec[1];
+            assert_eq!(report.data_conn_name, "bar".into());
+            assert_eq!(
+                report.data_conn_type,
+                "sabi::data_conn::tests_of_data_conn::AsyncDataConn"
+            );
+        }
+
+        #[test]
+        fn test_commit_and_rollback_ok() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -785,7 +936,9 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                assert!(manager.commit().is_ok());
+                let mut reports = manager.new_failure_reports();
+                assert!(manager.commit(&mut reports).is_ok());
+                manager.rollback(reports);
             }
 
             assert_eq!(
@@ -799,6 +952,10 @@ mod tests_of_data_conn {
                     "AsyncDataConn::commit 2",
                     "SyncDataConn::post_commit 1",
                     "AsyncDataConn::post_commit 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    "TxnFailureReports=[TxnFailureReport { data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }, TxnFailureReport { data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }]",
+                    "AsyncDataConn::on_txn_failure 2",
+                    "TxnFailureReports=[TxnFailureReport { data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }, TxnFailureReport { data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }]",
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -808,7 +965,7 @@ mod tests_of_data_conn {
         }
 
         #[test]
-        fn test_commit_with_order() {
+        fn test_commit_with_order_and_rollback_ok() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -832,7 +989,9 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                assert!(manager.commit().is_ok());
+                let mut reports = manager.new_failure_reports();
+                assert!(manager.commit(&mut reports).is_ok());
+                manager.rollback(reports);
             }
 
             assert_eq!(
@@ -850,6 +1009,12 @@ mod tests_of_data_conn {
                     "SyncDataConn::post_commit 1",
                     "SyncDataConn::post_commit 3",
                     "AsyncDataConn::post_commit 2", // because of async
+                    "SyncDataConn::on_txn_failure 1",
+                    "TxnFailureReports=[TxnFailureReport { data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }, TxnFailureReport { data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }, TxnFailureReport { data_conn_name: \"qux\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }]",
+                    "SyncDataConn::on_txn_failure 3",
+                    "TxnFailureReports=[TxnFailureReport { data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }, TxnFailureReport { data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }, TxnFailureReport { data_conn_name: \"qux\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }]",
+                    "AsyncDataConn::on_txn_failure 2",
+                    "TxnFailureReports=[TxnFailureReport { data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }, TxnFailureReport { data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }, TxnFailureReport { data_conn_name: \"qux\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }]",
                     "AsyncDataConn::close 2",
                     "AsyncDataConn::drop 2",
                     "SyncDataConn::close 1",
@@ -861,7 +1026,7 @@ mod tests_of_data_conn {
         }
 
         #[test]
-        fn test_commit_but_fail_first_sync_pre_commit() {
+        fn test_commit_and_rollback_but_fail_first_sync_pre_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -879,7 +1044,9 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                if let Err(e) = manager.commit() {
+                let mut reports = manager.new_failure_reports();
+
+                if let Err(e) = manager.commit(&mut reports) {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
@@ -891,14 +1058,42 @@ mod tests_of_data_conn {
                 } else {
                     panic!();
                 }
+
+                manager.rollback(reports);
             }
 
+            #[cfg(unix)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
                     "SyncDataConn::new 1",
                     "AsyncDataConn::new 2",
                     "SyncDataConn::pre_commit 1 failed",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 62),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 62),
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                ]
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "SyncDataConn::new 1",
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::pre_commit 1 failed",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 62),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 62),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -908,13 +1103,94 @@ mod tests_of_data_conn {
         }
 
         #[test]
-        fn test_commit_but_fail_first_async_pre_commit() {
+        fn test_commit_and_rollback_but_fail_first_async_pre_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
                 let mut manager = DataConnManager::new();
 
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::PreCommit);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
                 let conn = SyncDataConn::new(1, logger.clone(), Fail::PreCommit);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let mut reports = manager.new_failure_reports();
+
+                if let Err(e) = manager.commit(&mut reports) {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 2);
+                            assert_eq!(errors[0].0, "foo".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "zzz");
+                            assert_eq!(errors[1].0, "bar".into());
+                            assert_eq!(errors[1].1.reason::<String>().unwrap(), "yyy");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+
+                manager.rollback(reports);
+            }
+
+            #[cfg(unix)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::new 1",
+                    "SyncDataConn::pre_commit 1 failed",
+                    "AsyncDataConn::pre_commit 2 failed",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 181, BASE_LINE + 62),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 181, BASE_LINE + 62),
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                ]
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::new 1",
+                    "SyncDataConn::pre_commit 1 failed",
+                    "AsyncDataConn::pre_commit 2 failed",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 181, BASE_LINE + 62),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 181, BASE_LINE + 62),
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                ]
+            );
+        }
+
+        #[test]
+        fn test_commit_and_rollback_but_fail_second_pre_commit() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::Not);
                 let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
                 let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
                 let ssnnptr = SendSyncNonNull::new(nnptr);
@@ -926,26 +1202,58 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                if let Err(e) = manager.commit() {
+                let mut reports = manager.new_failure_reports();
+
+                if let Err(e) = manager.commit(&mut reports) {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "zzz");
+                            assert_eq!(errors[0].0, "bar".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "yyy");
                         }
                         _ => panic!(),
                     }
                 } else {
                     panic!();
                 }
+
+                manager.rollback(reports);
             }
 
+            #[cfg(unix)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
                     "SyncDataConn::new 1",
                     "AsyncDataConn::new 2",
-                    "SyncDataConn::pre_commit 1 failed",
+                    "SyncDataConn::pre_commit 1",
+                    "AsyncDataConn::pre_commit 2 failed",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 181),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 181),
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                ]
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "SyncDataConn::new 1",
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::pre_commit 1",
+                    "AsyncDataConn::pre_commit 2 failed",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 181),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 181),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -955,55 +1263,7 @@ mod tests_of_data_conn {
         }
 
         #[test]
-        fn test_commit_but_fail_second_pre_commit() {
-            let logger = Arc::new(Mutex::new(Vec::new()));
-
-            {
-                let mut manager = DataConnManager::new();
-
-                let conn = AsyncDataConn::new(1, logger.clone(), Fail::PreCommit);
-                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
-                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
-                let ssnnptr = SendSyncNonNull::new(nnptr);
-                manager.add(ssnnptr);
-
-                let conn = SyncDataConn::new(2, logger.clone(), Fail::Not);
-                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
-                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
-                let ssnnptr = SendSyncNonNull::new(nnptr);
-                manager.add(ssnnptr);
-
-                if let Err(e) = manager.commit() {
-                    match e.reason::<DataConnError>() {
-                        Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
-                            assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "yyy");
-                        }
-                        _ => panic!(),
-                    }
-                } else {
-                    panic!();
-                }
-            }
-
-            assert_eq!(
-                *logger.lock().unwrap(),
-                &[
-                    "AsyncDataConn::new 1",
-                    "SyncDataConn::new 2",
-                    "SyncDataConn::pre_commit 2",
-                    "AsyncDataConn::pre_commit 1 failed",
-                    "AsyncDataConn::close 1",
-                    "AsyncDataConn::drop 1",
-                    "SyncDataConn::close 2",
-                    "SyncDataConn::drop 2",
-                ]
-            );
-        }
-
-        #[test]
-        fn test_commit_but_fail_first_sync_commit() {
+        fn test_commit_and_rollback_but_fail_first_sync_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -1021,7 +1281,9 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                if let Err(e) = manager.commit() {
+                let mut reports = manager.new_failure_reports();
+
+                if let Err(e) = manager.commit(&mut reports) {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
@@ -1033,8 +1295,11 @@ mod tests_of_data_conn {
                 } else {
                     panic!();
                 }
+
+                manager.rollback(reports);
             }
 
+            #[cfg(unix)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
@@ -1043,6 +1308,33 @@ mod tests_of_data_conn {
                     "SyncDataConn::pre_commit 1",
                     "AsyncDataConn::pre_commit 2",
                     "SyncDataConn::commit 1 failed",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 47),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 47),
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                ]
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "SyncDataConn::new 1",
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::pre_commit 1",
+                    "AsyncDataConn::pre_commit 2",
+                    "SyncDataConn::commit 1 failed",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 47),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 47),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -1052,7 +1344,7 @@ mod tests_of_data_conn {
         }
 
         #[test]
-        fn test_commit_but_fail_first_async_commit() {
+        fn test_commit_and_rollback_but_fail_first_async_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -1070,7 +1362,9 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                if let Err(e) = manager.commit() {
+                let mut reports = manager.new_failure_reports();
+
+                if let Err(e) = manager.commit(&mut reports) {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
@@ -1082,8 +1376,11 @@ mod tests_of_data_conn {
                 } else {
                     panic!();
                 }
+
+                manager.rollback(reports);
             }
 
+            #[cfg(unix)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
@@ -1093,6 +1390,32 @@ mod tests_of_data_conn {
                     "AsyncDataConn::pre_commit 1",
                     "SyncDataConn::commit 2",
                     "AsyncDataConn::commit 1 failed",
+                    "AsyncDataConn::rollback 1",
+                    "SyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]", BASE_LINE + 158),
+                    "AsyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]", BASE_LINE + 158),
+                    "AsyncDataConn::close 1",
+                    "AsyncDataConn::drop 1",
+                    "SyncDataConn::close 2",
+                    "SyncDataConn::drop 2",
+                ]
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "AsyncDataConn::new 1",
+                    "SyncDataConn::new 2",
+                    "SyncDataConn::pre_commit 2",
+                    "AsyncDataConn::pre_commit 1",
+                    "SyncDataConn::commit 2",
+                    "AsyncDataConn::commit 1 failed",
+                    "AsyncDataConn::rollback 1",
+                    "SyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]", BASE_LINE + 158),
+                    "AsyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]", BASE_LINE + 158),
                     "AsyncDataConn::close 1",
                     "AsyncDataConn::drop 1",
                     "SyncDataConn::close 2",
@@ -1102,7 +1425,7 @@ mod tests_of_data_conn {
         }
 
         #[test]
-        fn test_commit_but_fail_second_commit() {
+        fn test_commit_and_rollback_but_fail_second_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -1120,7 +1443,9 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                if let Err(e) = manager.commit() {
+                let mut reports = manager.new_failure_reports();
+
+                if let Err(e) = manager.commit(&mut reports) {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
@@ -1132,8 +1457,11 @@ mod tests_of_data_conn {
                 } else {
                     panic!();
                 }
+
+                manager.rollback(reports);
             }
 
+            #[cfg(unix)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
@@ -1143,43 +1471,32 @@ mod tests_of_data_conn {
                     "AsyncDataConn::pre_commit 2",
                     "SyncDataConn::commit 1",
                     "AsyncDataConn::commit 2 failed",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 158),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 158),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
                     "AsyncDataConn::drop 2",
                 ]
             );
-        }
-
-        #[test]
-        fn test_rollback_and_first_is_sync() {
-            let logger = Arc::new(Mutex::new(Vec::new()));
-
-            {
-                let mut manager = DataConnManager::new();
-
-                let conn = SyncDataConn::new(1, logger.clone(), Fail::Not);
-                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
-                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
-                let ssnnptr = SendSyncNonNull::new(nnptr);
-                manager.add(ssnnptr);
-
-                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Not);
-                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
-                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
-                let ssnnptr = SendSyncNonNull::new(nnptr);
-                manager.add(ssnnptr);
-
-                manager.rollback();
-            }
-
+            #[cfg(windows)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
                     "SyncDataConn::new 1",
                     "AsyncDataConn::new 2",
-                    "SyncDataConn::rollback 1",
+                    "SyncDataConn::pre_commit 1",
+                    "AsyncDataConn::pre_commit 2",
+                    "SyncDataConn::commit 1",
+                    "AsyncDataConn::commit 2 failed",
                     "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 158),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 158),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -1189,65 +1506,213 @@ mod tests_of_data_conn {
         }
 
         #[test]
-        fn test_rollback_and_first_is_async() {
+        fn test_commit_and_rollback_but_fail_first_sync_post_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
                 let mut manager = DataConnManager::new();
 
-                let conn = AsyncDataConn::new(1, logger.clone(), Fail::Not);
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::PostCommit);
                 let boxed = Box::new(DataConnContainer::new("foo".to_string(), Box::new(conn)));
                 let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                let conn = SyncDataConn::new(2, logger.clone(), Fail::Not);
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::PostCommit);
                 let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
                 let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                manager.rollback();
+                let mut reports = manager.new_failure_reports();
+
+                if let Err(e) = manager.commit(&mut reports) {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 2);
+                            assert_eq!(errors[0].0, "foo".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[1].0, "bar".into());
+                            assert_eq!(errors[1].1.reason::<String>().unwrap(), "!!!");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+
+                manager.rollback(reports);
             }
 
+            #[cfg(unix)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
-                    "AsyncDataConn::new 1",
-                    "SyncDataConn::new 2",
-                    "SyncDataConn::rollback 2",
-                    "AsyncDataConn::rollback 1",
-                    "AsyncDataConn::close 1",
-                    "AsyncDataConn::drop 1",
-                    "SyncDataConn::close 2",
-                    "SyncDataConn::drop 2",
+                    "SyncDataConn::new 1",
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::pre_commit 1",
+                    "AsyncDataConn::pre_commit 2",
+                    "SyncDataConn::commit 1",
+                    "AsyncDataConn::commit 2",
+                    "SyncDataConn::post_commit 1 failed",
+                    "AsyncDataConn::post_commit 2 failed",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 79, BASE_LINE + 205),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 79, BASE_LINE + 205),
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                ]
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "SyncDataConn::new 1",
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::pre_commit 1",
+                    "AsyncDataConn::pre_commit 2",
+                    "SyncDataConn::commit 1",
+                    "AsyncDataConn::commit 2",
+                    "SyncDataConn::post_commit 1 failed",
+                    "AsyncDataConn::post_commit 2 failed",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 79, BASE_LINE + 205),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 79, BASE_LINE + 205),
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
                 ]
             );
         }
 
         #[test]
-        fn test_force_back_and_first_is_sync() {
+        fn test_commit_and_rollback_but_fail_first_async_post_commit() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::PostCommit);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::PostCommit);
+                let boxed = Box::new(DataConnContainer::new("foo".to_string(), Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let mut reports = manager.new_failure_reports();
+
+                if let Err(e) = manager.commit(&mut reports) {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 2);
+                            assert_eq!(errors[0].0, "foo".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[1].0, "bar".into());
+                            assert_eq!(errors[1].1.reason::<String>().unwrap(), "!!!");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+
+                manager.rollback(reports);
+            }
+
+            #[cfg(unix)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::new 1",
+                    "SyncDataConn::pre_commit 1",
+                    "AsyncDataConn::pre_commit 2",
+                    "SyncDataConn::commit 1",
+                    "AsyncDataConn::commit 2",
+                    "SyncDataConn::post_commit 1 failed",
+                    "AsyncDataConn::post_commit 2 failed",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 205, BASE_LINE + 79),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 205, BASE_LINE + 79),
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                ]
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::new 1",
+                    "SyncDataConn::pre_commit 1",
+                    "AsyncDataConn::pre_commit 2",
+                    "SyncDataConn::commit 1",
+                    "AsyncDataConn::commit 2",
+                    "SyncDataConn::post_commit 1 failed",
+                    "AsyncDataConn::post_commit 2 failed",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 205, BASE_LINE + 79),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 205, BASE_LINE + 79),
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                ]
+            );
+        }
+
+        #[test]
+        fn test_commit_and_rollback_but_fail_second_post_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
                 let mut manager = DataConnManager::new();
 
                 let conn = SyncDataConn::new(1, logger.clone(), Fail::Not);
-                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let boxed = Box::new(DataConnContainer::new("foo".to_string(), Box::new(conn)));
                 let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Not);
-                let boxed = Box::new(DataConnContainer::new("bar".to_string(), Box::new(conn)));
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::PostCommit);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
                 let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                assert!(manager.commit().is_ok());
-                manager.rollback();
+                let mut reports = manager.new_failure_reports();
+
+                if let Err(e) = manager.commit(&mut reports) {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 1);
+                            assert_eq!(errors[0].0, "bar".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "!!!");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+
+                manager.rollback(reports);
             }
 
+            #[cfg(unix)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
@@ -1258,9 +1723,33 @@ mod tests_of_data_conn {
                     "SyncDataConn::commit 1",
                     "AsyncDataConn::commit 2",
                     "SyncDataConn::post_commit 1",
-                    "AsyncDataConn::post_commit 2",
-                    "SyncDataConn::force_back 1",
-                    "AsyncDataConn::force_back 2",
+                    "AsyncDataConn::post_commit 2 failed",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 205),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 205),
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                ]
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "SyncDataConn::new 1",
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::pre_commit 1",
+                    "AsyncDataConn::pre_commit 2",
+                    "SyncDataConn::commit 1",
+                    "AsyncDataConn::commit 2",
+                    "SyncDataConn::post_commit 1",
+                    "AsyncDataConn::post_commit 2 failed",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 205),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 205),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -1270,7 +1759,49 @@ mod tests_of_data_conn {
         }
 
         #[test]
-        fn test_force_back_and_first_is_async() {
+        fn test_only_rollback_and_first_is_sync() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::Not);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Not);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let reports = manager.new_failure_reports();
+                manager.rollback(reports);
+            }
+
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "SyncDataConn::new 1",
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                ]
+            );
+        }
+
+        #[test]
+        fn test_only_rollback_and_first_is_async() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -1283,13 +1814,13 @@ mod tests_of_data_conn {
                 manager.add(ssnnptr);
 
                 let conn = SyncDataConn::new(2, logger.clone(), Fail::Not);
-                let boxed = Box::new(DataConnContainer::new("bar".to_string(), Box::new(conn)));
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
                 let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                assert!(manager.commit().is_ok());
-                manager.rollback();
+                let reports = manager.new_failure_reports();
+                manager.rollback(reports);
             }
 
             assert_eq!(
@@ -1297,20 +1828,387 @@ mod tests_of_data_conn {
                 &[
                     "AsyncDataConn::new 1",
                     "SyncDataConn::new 2",
-                    "SyncDataConn::pre_commit 2",
-                    "AsyncDataConn::pre_commit 1",
-                    "SyncDataConn::commit 2",
-                    "AsyncDataConn::commit 1",
-                    "SyncDataConn::post_commit 2",
-                    "AsyncDataConn::post_commit 1",
-                    "SyncDataConn::force_back 2",
-                    "AsyncDataConn::force_back 1",
+                    "SyncDataConn::rollback 2",
+                    "AsyncDataConn::rollback 1",
+                    "SyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                    "AsyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
                     "AsyncDataConn::close 1",
                     "AsyncDataConn::drop 1",
                     "SyncDataConn::close 2",
-                    "SyncDataConn::drop 2",
+                    "SyncDataConn::drop 2"
                 ]
             );
+        }
+
+        #[test]
+        fn test_only_rollback_and_second_rollback_failed() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::Not);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Rollback);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let reports = manager.new_failure_reports();
+                manager.rollback(reports);
+            }
+
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::rollback 1",
+                "AsyncDataConn::rollback 2 failed",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/data_conn.rs, line = {} }}) }}]", BASE_LINE + 229),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/data_conn.rs, line = {} }}) }}]", BASE_LINE + 229),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::rollback 1",
+                "AsyncDataConn::rollback 2 failed",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src\\data_conn.rs, line = {} }}) }}]", BASE_LINE + 229),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src\\data_conn.rs, line = {} }}) }}]", BASE_LINE + 229),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+        }
+
+        #[test]
+        fn test_only_rollback_and_first_rollback_failed() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::Rollback);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Not);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let reports = manager.new_failure_reports();
+                manager.rollback(reports);
+            }
+
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::rollback 1 failed",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/data_conn.rs, line = {} }}) }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 96),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/data_conn.rs, line = {} }}) }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 96),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::rollback 1 failed",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src\\data_conn.rs, line = {} }}) }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 96),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src\\data_conn.rs, line = {} }}) }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 96),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+        }
+
+        #[test]
+        fn test_commit_and_rollback_and_first_commit_failed_and_second_rollback_failed() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::Commit);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Rollback);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let mut reports = manager.new_failure_reports();
+                if let Err(e) = manager.commit(&mut reports) {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 1);
+                            assert_eq!(errors[0].0, "foo".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "ZZZ");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+                manager.rollback(reports);
+            }
+
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1 failed",
+                "SyncDataConn::rollback 1",
+                "AsyncDataConn::rollback 2 failed",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/data_conn.rs, line = {} }}) }}]", BASE_LINE + 47, BASE_LINE + 229),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/data_conn.rs, line = {} }}) }}]", BASE_LINE + 47, BASE_LINE + 229),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1 failed",
+                "SyncDataConn::rollback 1",
+                "AsyncDataConn::rollback 2 failed",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src\\data_conn.rs, line = {} }}) }}]", BASE_LINE + 47, BASE_LINE + 229),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src\\data_conn.rs, line = {} }}) }}]", BASE_LINE + 47, BASE_LINE + 229),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+        }
+
+        #[test]
+        fn test_commit_and_rollback_and_secod_commit_failed_and_first_rollback_failed() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::Rollback);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Commit);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let mut reports = manager.new_failure_reports();
+                if let Err(e) = manager.commit(&mut reports) {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 1);
+                            assert_eq!(errors[0].0, "bar".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "YYY");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+                manager.rollback(reports);
+            }
+
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1",
+                "AsyncDataConn::commit 2 failed",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 158),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 158),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1",
+                "AsyncDataConn::commit 2 failed",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 158),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 158),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+        }
+
+        #[test]
+        fn test_commit_and_rollback_and_pre_commit_become_committed_and_ok() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::PreCommitBecomeCommitted);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::PreCommitBecomeCommitted);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let mut reports = manager.new_failure_reports();
+                assert!(manager.commit(&mut reports).is_ok());
+                manager.rollback(reports);
+            }
+
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::post_commit 1",
+                "AsyncDataConn::post_commit 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}]"),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}]"),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+        }
+
+        #[test]
+        fn test_commit_and_rollback_and_pre_commit_become_committed_but_failed() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::PreCommitBecomeCommitted);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Commit);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let mut reports = manager.new_failure_reports();
+                if let Err(e) = manager.commit(&mut reports) {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 1);
+                            assert_eq!(errors[0].0, "bar".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "YYY");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+                manager.rollback(reports);
+            }
+
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "AsyncDataConn::commit 2 failed",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 158),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 158),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "AsyncDataConn::commit 2 failed",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 158),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 158),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
         }
     }
 }

--- a/src/data_hub.rs
+++ b/src/data_hub.rs
@@ -29,6 +29,7 @@ pub enum DataHubError {
     NoDataSrcToCreateDataConn {
         /// The name of the data source that could not be found.
         name: Arc<str>,
+
         /// The type name of the [`DataConn`] that was requested.
         data_conn_type: &'static str,
     },
@@ -77,7 +78,6 @@ impl DataHub {
         }
     }
 
-    #[allow(rustdoc::broken_intra_doc_links)]
     /// Registers a session-local data source with this [`DataHub`] instance.
     ///
     /// This method is similar to the global [`uses!`] macro but registers a data source
@@ -91,6 +91,7 @@ impl DataHub {
     ///
     /// * `name`: The unique name for the local data source.
     /// * `ds`: The [`DataSrc`] instance to register.
+    #[allow(rustdoc::broken_intra_doc_links)]
     pub fn uses<S, C>(&mut self, name: impl Into<Arc<str>>, ds: S)
     where
         S: DataSrc<C>,
@@ -137,16 +138,6 @@ impl DataHub {
     }
 
     #[inline]
-    fn commit(&mut self) -> errs::Result<()> {
-        self.data_conn_manager.commit()
-    }
-
-    #[inline]
-    fn rollback(&mut self) {
-        self.data_conn_manager.rollback()
-    }
-
-    #[inline]
     fn end(&mut self) {
         self.data_conn_manager.close();
         self.fixed = false;
@@ -179,14 +170,14 @@ impl DataHub {
         r
     }
 
-    /// Executes a given logic function within a transaction.
+    /// Executes a given logic function within a managed transaction.
     ///
-    /// This method first sets up local data sources, then runs the provided closure.
-    /// If the closure returns `Ok`, it attempts to commit all changes. If the commit fails,
-    /// or if the logic function itself returns an [`errs::Err`], a rollback operation
-    /// is performed. After succeeding `pre_commit` and `commit` methods of all [`DataConn`]s,
-    /// `post_commit` methods of all [`DataConn`]s are executed.
-    /// Finally, it cleans up the [`DataHub`]'s session resources.
+    /// This method starts by setting up local data sources, runs the provided closure,
+    /// and then attempts to commit all open data connections in the session.
+    ///
+    /// If any error occurs during the execution of the closure or during the commit phase,
+    /// it initiates a rollback on all data connections and reports the transaction failure details.
+    /// Finally, it cleans up session resources.
     ///
     /// # Parameters
     ///
@@ -195,8 +186,8 @@ impl DataHub {
     ///
     /// # Returns
     ///
-    /// * `errs::Result<()>`: The final result of the transaction (success or failure of
-    ///   logic/commit), or an error if executing `logic_fn` fails.
+    /// * `errs::Result<()>`: `Ok(())` if the closure and the commit phase succeed,
+    ///   or an [`errs::Err`] if any phase fails.
     pub fn txn<F>(&mut self, mut logic_fn: F) -> errs::Result<()>
     where
         F: FnMut(&mut DataHub) -> errs::Result<()>,
@@ -205,12 +196,16 @@ impl DataHub {
         if r.is_ok() {
             r = logic_fn(self);
         }
+
+        let mut reports = self.data_conn_manager.new_failure_reports();
+
         if r.is_ok() {
-            r = self.commit();
+            r = self.data_conn_manager.commit(&mut reports);
         }
         if r.is_err() {
-            self.rollback();
+            self.data_conn_manager.rollback(reports);
         }
+
         self.end();
         r
     }
@@ -274,7 +269,7 @@ impl DataHub {
 #[cfg(test)]
 mod tests_of_data_hub {
     use super::*;
-    use crate::AsyncGroup;
+    use crate::{AsyncGroup, TxnFailureReport};
     use std::sync::Mutex;
 
     #[derive(Clone, Copy, PartialEq)]
@@ -346,23 +341,28 @@ mod tests_of_data_hub {
                 Ok(())
             }
         }
-        fn post_commit(&mut self, _ag: &mut AsyncGroup) {
+        fn is_committed(&self) -> bool {
+            false
+        }
+        fn post_commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             self.logger
                 .lock()
                 .unwrap()
                 .push(format!("MyDataConn::post_commit {}", self.id));
+            Ok(())
         }
-        fn rollback(&mut self, _ag: &mut AsyncGroup) {
+        fn rollback(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             self.logger
                 .lock()
                 .unwrap()
                 .push(format!("MyDataConn::rollback {}", self.id));
+            Ok(())
         }
-        fn force_back(&mut self, _ag: &mut AsyncGroup) {
+        fn on_txn_failure(&mut self, _ag: &mut AsyncGroup, _reports: &[TxnFailureReport]) {
             self.logger
                 .lock()
                 .unwrap()
-                .push(format!("MyDataConn::force_back {}", self.id));
+                .push(format!("MyDataConn::on_txn_failure {}", self.id));
         }
         fn close(&mut self) {
             self.logger
@@ -1004,6 +1004,8 @@ mod tests_of_data_hub {
                 "MyDataConn::new 2",
                 "MyDataConn::rollback 1",
                 "MyDataConn::rollback 2",
+                "MyDataConn::on_txn_failure 1",
+                "MyDataConn::on_txn_failure 2",
                 "MyDataConn::close 1",
                 "MyDataConn::drop 1",
                 "MyDataConn::close 2",

--- a/src/data_src/global_setup.rs
+++ b/src/data_src/global_setup.rs
@@ -43,7 +43,7 @@ impl Drop for AutoShutdown {
 ///
 /// Global data sources added via this function can be set up via [`setup`] or [`setup_with_order`].
 ///
-/// If `setup` or `setup_with_order` has already been called, this function will return an `errs::Err`.  
+/// If `setup` or `setup_with_order` has already been called, this function will return an `errs::Err`.
 ///
 /// # Parameters
 ///
@@ -192,8 +192,6 @@ pub fn setup_with_order(names: &[&str]) -> errs::Result<AutoShutdown> {
 }
 
 #[doc(hidden)]
-/// Helper function to create a [`StaticDataSrcContainer`] for static registration.
-/// This function is used by the [`uses!`] macro.
 pub fn create_static_data_src_container<S, C>(
     name: &'static str,
     data_src: S,
@@ -248,7 +246,8 @@ inventory::collect!(StaticDataSrcRegistration);
 /// struct MyDataConn;
 /// impl DataConn for MyDataConn {
 ///     fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> { Ok(()) }
-///     fn rollback(&mut self, _ag: &mut AsyncGroup) {}
+///     fn rollback(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> { Ok(()) }
+///     fn is_committed(&self) -> bool { false }
 ///     fn close(&mut self) {}
 /// }
 ///

--- a/src/data_src/mod.rs
+++ b/src/data_src/mod.rs
@@ -45,6 +45,7 @@ pub enum DataSrcError {
     FailToCastDataConn {
         /// The name of the data connection that failed to cast.
         name: Arc<str>,
+
         /// The type name to which the [`DataConn`] attempted to cast.
         target_type: &'static str,
     },
@@ -53,6 +54,7 @@ pub enum DataSrcError {
     FailToCreateDataConn {
         /// The name of the data source that failed to be created.
         name: Arc<str>,
+
         /// The type name of the [`DataConn`] that failed to be created.
         data_conn_type: &'static str,
     },
@@ -62,6 +64,7 @@ pub enum DataSrcError {
     NotFoundDataSrcToCreateDataConn {
         /// The name of the data source that could not be found.
         name: Arc<str>,
+
         /// The type name of the [`DataConn`] that was requested.
         data_conn_type: &'static str,
     },
@@ -385,7 +388,12 @@ mod tests_of_data_src {
         fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             Ok(())
         }
-        fn rollback(&mut self, _ag: &mut AsyncGroup) {}
+        fn is_committed(&self) -> bool {
+            false
+        }
+        fn rollback(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+            Ok(())
+        }
         fn close(&mut self) {}
     }
 
@@ -399,7 +407,12 @@ mod tests_of_data_src {
         fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             Ok(())
         }
-        fn rollback(&mut self, _ag: &mut AsyncGroup) {}
+        fn is_committed(&self) -> bool {
+            false
+        }
+        fn rollback(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+            Ok(())
+        }
         fn close(&mut self) {}
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ mod data_conn;
 mod data_hub;
 mod data_src;
 mod non_null;
+mod txn_failure;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -53,7 +54,6 @@ pub mod tokio;
 /// Functions are added using the `add` method and are then run concurrently in separate threads.
 /// The `AsyncGroup` ensures that all tasks finish before proceeding,
 /// and can collect any errors that occur.
-/// This structure implements `Send` and `Sync`.
 pub struct AsyncGroup {
     handlers: Vec<(usize, thread::JoinHandle<errs::Result<()>>)>,
     _index: usize,
@@ -94,6 +94,15 @@ pub trait DataConn {
     /// supported by transactions beforehand.
     /// This allows other update operations to be rolled back if the operations in this method
     /// fail.
+    ///
+    /// # Parameters
+    ///
+    /// * `ag`: A mutable reference to an [`AsyncGroup`]. This can be used to run the pre-commit
+    ///   asynchronously in a separate thread.
+    ///
+    /// # Returns
+    ///
+    /// * `errs::Result<()>`: `Ok(())` if pre-commit is successful, or an [`errs::Err`] if it fails.
     fn pre_commit(&mut self, ag: &mut AsyncGroup) -> errs::Result<()> {
         Ok(())
     }
@@ -109,21 +118,17 @@ pub trait DataConn {
     ///
     /// * `ag`: A mutable reference to an [`AsyncGroup`] for potentially offloading
     ///   concurrent post-commit operations.
-    fn post_commit(&mut self, ag: &mut AsyncGroup) {}
-
-    /// Determines whether a "force back" operation is required for this data connection.
-    ///
-    /// A force back is typically executed if one external data service successfully commits
-    /// its changes, but a subsequent external data service within the same transaction fails
-    /// its commit. This method indicates if the committed changes of *this* data service
-    /// need to be undone (forced back).
     ///
     /// # Returns
     ///
-    /// * `bool`: `true` if a force back is needed for this connection, `false` otherwise.
-    fn should_force_back(&self) -> bool {
-        false
+    /// * `errs::Result<()>`: `Ok(())` if post-commit tasks succeed, or an [`errs::Err`] if they
+    ///   fail.
+    fn post_commit(&mut self, ag: &mut AsyncGroup) -> errs::Result<()> {
+        Ok(())
     }
+
+    /// Returns whether the transaction on this connection has been successfully committed.
+    fn is_committed(&self) -> bool;
 
     /// Rolls back any changes made within this data connection's transaction.
     ///
@@ -132,22 +137,25 @@ pub trait DataConn {
     ///
     /// # Parameters
     ///
-    /// * `ag`: A mutable reference to an [`AsyncGroup`] for potentially offloading
-    ///   time-consuming rollback operations to a separate thread.
-    fn rollback(&mut self, ag: &mut AsyncGroup);
-
-    /// Executes an operation to revert committed changes.
+    /// * `ag`: A mutable reference to an [`AsyncGroup`]. This can be used to run the rollback
+    ///   asynchronously in a separate thread.
     ///
-    /// This method provides an opportunity to undo changes that were successfully committed
-    /// to this external data service, typically when a commit fails for *another* data service
-    /// within the same distributed transaction, necessitating a rollback of already committed
-    /// changes.
+    /// # Returns
+    ///
+    /// * `errs::Result<()>`: `Ok(())` if the rollback is successful, or an [`errs::Err`] if it
+    ///   fails.
+    fn rollback(&mut self, ag: &mut AsyncGroup) -> errs::Result<()>;
+
+    /// A lifecycle callback invoked when a transaction fails and a rollback is executed.
+    ///
+    /// This allows the data connection to handle post-failure tasks or custom logic
+    /// based on the provided transaction failure reports.
     ///
     /// # Parameters
     ///
-    /// * `ag`: A mutable reference to an [`AsyncGroup`] for potentially offloading
-    ///   concurrent force back operations.
-    fn force_back(&mut self, ag: &mut AsyncGroup) {}
+    /// * `ag`: A mutable reference to an [`AsyncGroup`] for asynchronous task execution.
+    /// * `reports`: A slice of [`TxnFailureReport`] containing failure details for all connections.
+    fn on_txn_failure(&mut self, ag: &mut AsyncGroup, reports: &[TxnFailureReport]) {}
 
     /// Closes the connection to the external data service.
     ///
@@ -162,7 +170,12 @@ impl DataConn for NoopDataConn {
     fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
         Ok(())
     }
-    fn rollback(&mut self, _ag: &mut AsyncGroup) {}
+    fn is_committed(&self) -> bool {
+        false
+    }
+    fn rollback(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+        Ok(())
+    }
     fn close(&mut self) {}
 }
 
@@ -173,12 +186,13 @@ where
 {
     drop_fn: fn(*const DataConnContainer),
     is_fn: fn(any::TypeId) -> bool,
+    type_fn: fn() -> &'static str,
     commit_fn: fn(*const DataConnContainer, &mut AsyncGroup) -> errs::Result<()>,
     pre_commit_fn: fn(*const DataConnContainer, &mut AsyncGroup) -> errs::Result<()>,
-    post_commit_fn: fn(*const DataConnContainer, &mut AsyncGroup),
-    should_force_back_fn: fn(*const DataConnContainer) -> bool,
-    rollback_fn: fn(*const DataConnContainer, &mut AsyncGroup),
-    force_back_fn: fn(*const DataConnContainer, &mut AsyncGroup),
+    post_commit_fn: fn(*const DataConnContainer, &mut AsyncGroup) -> errs::Result<()>,
+    is_committed_fn: fn(*const DataConnContainer) -> bool,
+    rollback_fn: fn(*const DataConnContainer, &mut AsyncGroup) -> errs::Result<()>,
+    on_txn_failure_fn: fn(*const DataConnContainer, &mut AsyncGroup, &[TxnFailureReport]),
     close_fn: fn(*const DataConnContainer),
 
     name: Arc<str>,
@@ -292,8 +306,6 @@ pub struct AutoShutdown {}
 ///
 /// The [`DataHub`] is capable of performing aggregated transactional operations
 /// on all [`DataConn`] objects created from its registered [`DataSrc`] instances.
-///
-/// This structure implements `Send`.
 pub struct DataHub {
     local_data_src_manager: DataSrcManager,
     data_src_map: HashMap<Arc<str>, (bool, usize)>,
@@ -344,4 +356,68 @@ pub struct StaticDataSrcRegistration {
 struct SendSyncNonNull<T: Send + Sync> {
     non_null_ptr: ptr::NonNull<T>,
     _phantom: marker::PhantomData<cell::Cell<T>>,
+}
+
+/// Represents the cause of a transaction failure for a specific data connection.
+#[derive(Debug)]
+pub enum TxnFailureCause {
+    /// No failure occurred, and the transaction was successfully committed.
+    NoneByCommitted,
+    /// No failure occurred, but the transaction was not committed (e.g., because
+    /// another connection in the transaction failed before this one could commit).
+    NoneByUncommitted,
+    /// The execution or pre-commit phase of the data connection failed.
+    RunFailure(errs::Err),
+    /// The commit phase of the data connection failed.
+    CommitFailure(errs::Err),
+    /// The post-commit phase of the data connection failed.
+    PostCommitFailure(errs::Err),
+}
+
+/// Represents the rollback status of a data connection in a failed transaction.
+#[derive(Debug)]
+pub enum TxnFailureRollback {
+    /// Rollback was not executed or not applicable (e.g., because the connection
+    /// was already committed).
+    None,
+    /// The rollback was executed and succeeded.
+    Success,
+    /// The rollback was executed but failed.
+    Failure(errs::Err),
+}
+
+/// Represents the suggested recovery action for a data connection after a transaction failure.
+#[derive(Debug, PartialEq)]
+pub enum TxnFailureRecovery {
+    /// No recovery action is required.
+    NoActionRequired,
+    /// The transaction was committed, but the post-commit phase failed.
+    /// The post-commit operations should be retried.
+    RetryPostCommit,
+    /// The transaction was successfully rolled back.
+    /// The transaction can be rerun and committed again.
+    RerunAndCommit,
+    /// The transaction failed to commit and rollback was not run or failed.
+    /// Investigation is required before rerunning.
+    InvestigateAndRerunAndCommit,
+    /// The rollback failed or has an inconsistent state.
+    /// Investigation is required to resolve the rollback.
+    InvestigateAndRollback,
+    /// The connection was committed but other connections failed and rolled back.
+    /// Compensating operations must be performed.
+    CompensateRollback,
+}
+
+/// A report detailing the transaction failure cause and rollback status
+/// for a specific data connection.
+#[derive(Debug)]
+pub struct TxnFailureReport {
+    /// The name of the data connection.
+    pub data_conn_name: Arc<str>,
+    /// The type name of the data connection.
+    pub data_conn_type: &'static str,
+    /// The cause of the transaction failure.
+    pub cause: TxnFailureCause,
+    /// The rollback status of the data connection.
+    pub rollback: TxnFailureRollback,
 }

--- a/src/tokio/async_group.rs
+++ b/src/tokio/async_group.rs
@@ -21,7 +21,7 @@ impl AsyncGroup {
     ///
     /// The provided future will be polled along with others in this group.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
     /// * `future` - The future to add. It must implement `Future<Output = errs::Result<()>>`,
     ///              `Send`, and have a `'static` lifetime.

--- a/src/tokio/data_acc.rs
+++ b/src/tokio/data_acc.rs
@@ -10,7 +10,7 @@ impl DataAcc for DataHub {
     /// This asynchronous method attempts to get a data connection identified by `name`.
     /// The connection type `C` must implement the `DataConn` trait and have a `'static` lifetime.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
     /// * `name` - An identifier for the data connection to retrieve.
     ///
@@ -35,6 +35,7 @@ impl DataAcc for DataHub {
 mod tests_of_data_acc {
     use super::super::{logic, AsyncGroup, DataSrc};
     use super::*;
+    use crate::TxnFailureReport;
     use std::sync::{Arc, Mutex};
 
     struct FooDataConn {
@@ -80,18 +81,24 @@ mod tests_of_data_acc {
             logger.push(format!("FooDataConn::pre_commit_async {}", self.id));
             Ok(())
         }
-        async fn post_commit_async(&mut self, _ag: &mut AsyncGroup) {
+        async fn post_commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             let mut logger = self.logger.lock().unwrap();
             logger.push(format!("FooDataConn::post_commit_async {}", self.id));
+            Ok(())
         }
-        fn should_force_back(&self) -> bool {
+        fn is_committed(&self) -> bool {
             self.committed
         }
-        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {
+        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             let mut logger = self.logger.lock().unwrap();
             logger.push(format!("FooDataConn::rollback_async {}", self.id));
+            Ok(())
         }
-        async fn force_back_async(&mut self, _ag: &mut AsyncGroup) {
+        async fn on_txn_failure(
+            &mut self,
+            _ag: &mut AsyncGroup,
+            _reports: Arc<[TxnFailureReport]>,
+        ) {
             let mut logger = self.logger.lock().unwrap();
             logger.push(format!("FooDataConn::force_back_async {}", self.id));
         }
@@ -217,18 +224,24 @@ mod tests_of_data_acc {
             logger.push(format!("BarDataConn::pre_commit_async {}", self.id));
             Ok(())
         }
-        async fn post_commit_async(&mut self, _ag: &mut AsyncGroup) {
+        async fn post_commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             let mut logger = self.logger.lock().unwrap();
             logger.push(format!("BarDataConn::post_commit_async {}", self.id));
+            Ok(())
         }
-        fn should_force_back(&self) -> bool {
+        fn is_committed(&self) -> bool {
             self.committed
         }
-        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {
+        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             let mut logger = self.logger.lock().unwrap();
             logger.push(format!("BarDataConn::rollback_async {}", self.id));
+            Ok(())
         }
-        async fn force_back_async(&mut self, _ag: &mut AsyncGroup) {
+        async fn on_txn_failure(
+            &mut self,
+            _ag: &mut AsyncGroup,
+            _reports: Arc<[TxnFailureReport]>,
+        ) {
             let mut logger = self.logger.lock().unwrap();
             logger.push(format!("BarDataConn::force_back_async {}", self.id));
         }

--- a/src/tokio/data_acc.rs
+++ b/src/tokio/data_acc.rs
@@ -94,7 +94,7 @@ mod tests_of_data_acc {
             logger.push(format!("FooDataConn::rollback_async {}", self.id));
             Ok(())
         }
-        async fn on_txn_failure(
+        async fn on_txn_failure_async(
             &mut self,
             _ag: &mut AsyncGroup,
             _reports: Arc<[TxnFailureReport]>,
@@ -237,7 +237,7 @@ mod tests_of_data_acc {
             logger.push(format!("BarDataConn::rollback_async {}", self.id));
             Ok(())
         }
-        async fn on_txn_failure(
+        async fn on_txn_failure_async(
             &mut self,
             _ag: &mut AsyncGroup,
             _reports: Arc<[TxnFailureReport]>,

--- a/src/tokio/data_conn.rs
+++ b/src/tokio/data_conn.rs
@@ -150,7 +150,7 @@ where
     C: DataConn + 'static,
 {
     let container = unsafe { &mut *(ptr as *mut DataConnContainer<C>) };
-    Box::pin(container.data_conn.on_txn_failure(ag, reports))
+    Box::pin(container.data_conn.on_txn_failure_async(ag, reports))
 }
 
 fn close_data_conn<C>(ptr: *const DataConnContainer)
@@ -520,7 +520,11 @@ mod tests_of_data_conn {
                 .push(format!("SyncDataConn::rollback {}", id));
             Ok(())
         }
-        async fn on_txn_failure(&mut self, _ag: &mut AsyncGroup, reports: Arc<[TxnFailureReport]>) {
+        async fn on_txn_failure_async(
+            &mut self,
+            _ag: &mut AsyncGroup,
+            reports: Arc<[TxnFailureReport]>,
+        ) {
             let logger = self.logger.clone();
             let mut logger = logger.lock().unwrap();
             logger.push(format!("SyncDataConn::on_txn_failure {}", self.id));
@@ -652,7 +656,11 @@ mod tests_of_data_conn {
             });
             Ok(())
         }
-        async fn on_txn_failure(&mut self, ag: &mut AsyncGroup, reports: Arc<[TxnFailureReport]>) {
+        async fn on_txn_failure_async(
+            &mut self,
+            ag: &mut AsyncGroup,
+            reports: Arc<[TxnFailureReport]>,
+        ) {
             let reports_log = format!("TxnFailureReports={:?}", reports);
             let logger = self.logger.clone();
             let id = self.id;
@@ -1230,9 +1238,9 @@ mod tests_of_data_conn {
                     "SyncDataConn::rollback 2",
                     "AsyncDataConn::rollback 1",
                     "SyncDataConn::on_txn_failure 2",
-                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 195),
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 199),
                     "AsyncDataConn::on_txn_failure 1",
-                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 195),
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 199),
                     "AsyncDataConn::close 1",
                     "AsyncDataConn::drop 1",
                     "SyncDataConn::close 2",
@@ -1367,9 +1375,9 @@ mod tests_of_data_conn {
                     "AsyncDataConn::commit 1 failed",
                     "AsyncDataConn::rollback 1",
                     "SyncDataConn::on_txn_failure 2",
-                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]", BASE_LINE + 173),
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]", BASE_LINE + 177),
                     "AsyncDataConn::on_txn_failure 1",
-                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]", BASE_LINE + 173),
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]", BASE_LINE + 177),
                     "AsyncDataConn::close 1",
                     "AsyncDataConn::drop 1",
                     "SyncDataConn::close 2",
@@ -1446,9 +1454,9 @@ mod tests_of_data_conn {
                     "AsyncDataConn::commit 2 failed",
                     "AsyncDataConn::rollback 2",
                     "SyncDataConn::on_txn_failure 1",
-                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 177),
                     "AsyncDataConn::on_txn_failure 2",
-                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 177),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -1528,9 +1536,9 @@ mod tests_of_data_conn {
                     "SyncDataConn::post_commit 1 failed",
                     "AsyncDataConn::post_commit 2 failed",
                     "SyncDataConn::on_txn_failure 1",
-                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89, BASE_LINE + 216),
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89, BASE_LINE + 220),
                     "AsyncDataConn::on_txn_failure 2",
-                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89, BASE_LINE + 216),
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89, BASE_LINE + 220),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -1609,9 +1617,9 @@ mod tests_of_data_conn {
                 "SyncDataConn::post_commit 1 failed",
                 "AsyncDataConn::post_commit 2 failed",
                 "SyncDataConn::on_txn_failure 1",
-                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = 610 }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89),
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 220, BASE_LINE + 89),
                 "AsyncDataConn::on_txn_failure 2",
-                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = 610 }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89),
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 220, BASE_LINE + 89),
                 "AsyncDataConn::close 2",
                 "AsyncDataConn::drop 2",
                 "SyncDataConn::close 1",
@@ -1876,9 +1884,9 @@ mod tests_of_data_conn {
                 "SyncDataConn::rollback 2",
                 "AsyncDataConn::rollback 1 failed",
                 "SyncDataConn::on_txn_failure 2",
-                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/tokio/data_conn.rs, line = 634 }}) }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/tokio/data_conn.rs, line = {} }}) }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 244),
                 "AsyncDataConn::on_txn_failure 1",
-                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/tokio/data_conn.rs, line = 634 }}) }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/tokio/data_conn.rs, line = {} }}) }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 244),
                 "AsyncDataConn::close 1",
                 "AsyncDataConn::drop 1",
                 "SyncDataConn::close 2",
@@ -1948,9 +1956,9 @@ mod tests_of_data_conn {
                 "SyncDataConn::rollback 1",
                 "AsyncDataConn::rollback 2 failed",
                 "SyncDataConn::on_txn_failure 1",
-                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/tokio/data_conn.rs, line = {} }}) }}]", BASE_LINE + 52, BASE_LINE + 240),
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/tokio/data_conn.rs, line = {} }}) }}]", BASE_LINE + 52, BASE_LINE + 244),
                 "AsyncDataConn::on_txn_failure 2",
-                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/tokio/data_conn.rs, line = {} }}) }}]", BASE_LINE + 52, BASE_LINE + 240),
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/tokio/data_conn.rs, line = {} }}) }}]", BASE_LINE + 52, BASE_LINE + 244),
                 "SyncDataConn::close 1",
                 "SyncDataConn::drop 1",
                 "AsyncDataConn::close 2",
@@ -2023,9 +2031,9 @@ mod tests_of_data_conn {
                 "AsyncDataConn::commit 2 failed",
                 "AsyncDataConn::rollback 2",
                 "SyncDataConn::on_txn_failure 1",
-                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 177),
                 "AsyncDataConn::on_txn_failure 2",
-                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 177),
                 "SyncDataConn::close 1",
                 "SyncDataConn::drop 1",
                 "AsyncDataConn::close 2",
@@ -2142,9 +2150,9 @@ mod tests_of_data_conn {
                 "AsyncDataConn::commit 2 failed",
                 "AsyncDataConn::rollback 2",
                 "SyncDataConn::on_txn_failure 1",
-                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 177),
                 "AsyncDataConn::on_txn_failure 2",
-                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 177),
                 "SyncDataConn::close 1",
                 "SyncDataConn::drop 1",
                 "AsyncDataConn::close 2",

--- a/src/tokio/data_conn.rs
+++ b/src/tokio/data_conn.rs
@@ -3,6 +3,7 @@
 // See the file LICENSE in this distribution for more details.
 
 use super::{AsyncGroup, DataConn, DataConnContainer, DataConnManager, SendSyncNonNull};
+use crate::{TxnFailureCause, TxnFailureReport, TxnFailureRollback};
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -26,10 +27,17 @@ pub enum DataConnError {
         errors: Vec<(Arc<str>, errs::Err)>,
     },
 
+    /// An error indicating that one or more data connections failed during the post-commit process.
+    FailToPostCommitDataConn {
+        /// A vector of errors, each containing the name of the data connection and the error itself.
+        errors: Vec<(Arc<str>, errs::Err)>,
+    },
+
     /// An error indicating that a data connection could not be cast to the target type.
     FailToCastDataConn {
         /// The name of the data connection that failed to cast.
         name: Arc<str>,
+
         /// The string representation of the target type to which the connection could not be cast.
         target_type: &'static str,
     },
@@ -43,12 +51,13 @@ where
         Self {
             drop_fn: drop_data_conn::<C>,
             is_fn: is_data_conn::<C>,
+            type_fn: type_of_data_conn::<C>,
             commit_fn: commit_data_conn_async::<C>,
             pre_commit_fn: pre_commit_data_conn_async::<C>,
             post_commit_fn: post_commit_data_conn_async::<C>,
-            should_force_back_fn: should_force_back_data_conn::<C>,
+            is_committed_fn: is_committed_data_conn::<C>,
             rollback_fn: rollback_data_conn_async::<C>,
-            force_back_fn: force_back_data_conn_async::<C>,
+            on_txn_failure_fn: on_txn_failure_data_conn_async::<C>,
             close_fn: close_data_conn::<C>,
 
             name: name.into(),
@@ -71,6 +80,13 @@ where
     C: DataConn + 'static,
 {
     any::TypeId::of::<C>() == type_id
+}
+
+fn type_of_data_conn<C>() -> &'static str
+where
+    C: DataConn + 'static,
+{
+    any::type_name::<C>()
 }
 
 fn commit_data_conn_async<C>(
@@ -98,7 +114,7 @@ where
 fn post_commit_data_conn_async<C>(
     ptr: *const DataConnContainer,
     ag: &mut AsyncGroup,
-) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>
+) -> Pin<Box<dyn Future<Output = errs::Result<()>> + Send + '_>>
 where
     C: DataConn + 'static,
 {
@@ -106,18 +122,18 @@ where
     Box::pin(container.data_conn.post_commit_async(ag))
 }
 
-fn should_force_back_data_conn<C>(ptr: *const DataConnContainer) -> bool
+fn is_committed_data_conn<C>(ptr: *const DataConnContainer) -> bool
 where
     C: DataConn + 'static,
 {
     let container = unsafe { &*(ptr as *const DataConnContainer<C>) };
-    container.data_conn.should_force_back()
+    container.data_conn.is_committed()
 }
 
 fn rollback_data_conn_async<C>(
     ptr: *const DataConnContainer,
     ag: &mut AsyncGroup,
-) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>
+) -> Pin<Box<dyn Future<Output = errs::Result<()>> + Send + '_>>
 where
     C: DataConn + 'static,
 {
@@ -125,15 +141,16 @@ where
     Box::pin(container.data_conn.rollback_async(ag))
 }
 
-fn force_back_data_conn_async<C>(
+fn on_txn_failure_data_conn_async<C>(
     ptr: *const DataConnContainer,
     ag: &mut AsyncGroup,
+    reports: Arc<[TxnFailureReport]>,
 ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>
 where
     C: DataConn + 'static,
 {
     let container = unsafe { &mut *(ptr as *mut DataConnContainer<C>) };
-    Box::pin(container.data_conn.force_back_async(ag))
+    Box::pin(container.data_conn.on_txn_failure(ag, reports))
 }
 
 fn close_data_conn<C>(ptr: *const DataConnContainer)
@@ -195,23 +212,6 @@ impl DataConnManager {
         None
     }
 
-    fn index_errors_to_named_errors(
-        &self,
-        indexed_errors: Vec<(usize, errs::Err)>,
-    ) -> Vec<(Arc<str>, errs::Err)> {
-        let mut ret_vec = Vec::new();
-
-        for (i, err) in indexed_errors.into_iter() {
-            if let Some(ssnnptr) = &self.vec[i] {
-                let ptr = ssnnptr.non_null_ptr.as_ptr();
-                let name = unsafe { (*ptr).name.clone() };
-                ret_vec.push((name, err));
-            }
-        }
-
-        ret_vec
-    }
-
     pub(crate) fn to_typed_ptr<C>(
         ssnnptr: &SendSyncNonNull<DataConnContainer>,
     ) -> errs::Result<*mut DataConnContainer<C>>
@@ -234,7 +234,19 @@ impl DataConnManager {
         Ok(typed_ptr)
     }
 
-    pub(crate) async fn commit_async(&self) -> errs::Result<()> {
+    pub(crate) fn new_failure_reports(&self) -> Vec<TxnFailureReport> {
+        let mut reports = Vec::new();
+        for ssnnptr in self.vec.iter().flatten() {
+            let ptr = ssnnptr.non_null_ptr.as_ptr();
+            let name = unsafe { (*ptr).name.clone() };
+            let type_fn = unsafe { (*ptr).type_fn };
+            let report = TxnFailureReport::new(name, type_fn());
+            reports.push(report);
+        }
+        reports
+    }
+
+    pub(crate) async fn commit_async(&self, reports: &mut [TxnFailureReport]) -> errs::Result<()> {
         let mut indexed_errors = Vec::new();
 
         let mut ag = AsyncGroup::new();
@@ -250,14 +262,26 @@ impl DataConnManager {
         ag.join_and_collect_errors_async(&mut indexed_errors).await;
 
         if !indexed_errors.is_empty() {
+            let mut errors = Vec::new();
+            for (i, err) in indexed_errors.into_iter() {
+                let report = &mut reports[i];
+                report.cause = TxnFailureCause::RunFailure(err.clone());
+                errors.push((report.data_conn_name.clone(), err));
+            }
             return Err(errs::Err::new(DataConnError::FailToPreCommitDataConn {
-                errors: self.index_errors_to_named_errors(indexed_errors),
+                errors,
             }));
         }
 
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
+            let is_committed_fn = unsafe { (*ptr).is_committed_fn };
+            if is_committed_fn(ptr) {
+                // Set this alongside the committed state by PreCommit, during the rollback process
+                //report.cause = TxnFailureCause::NoneByCommitted;
+                continue;
+            }
             let commit_fn = unsafe { (*ptr).commit_fn };
             ag._index = i;
             if let Err(err) = commit_fn(ptr, &mut ag).await {
@@ -268,8 +292,14 @@ impl DataConnManager {
         ag.join_and_collect_errors_async(&mut indexed_errors).await;
 
         if !indexed_errors.is_empty() {
+            let mut errors = Vec::new();
+            for (i, err) in indexed_errors.into_iter() {
+                let report = &mut reports[i];
+                report.cause = TxnFailureCause::CommitFailure(err.clone());
+                errors.push((report.data_conn_name.clone(), err));
+            }
             return Err(errs::Err::new(DataConnError::FailToCommitDataConn {
-                errors: self.index_errors_to_named_errors(indexed_errors),
+                errors,
             }));
         }
 
@@ -278,27 +308,66 @@ impl DataConnManager {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let post_commit_fn = unsafe { (*ptr).post_commit_fn };
             ag._index = i;
-            post_commit_fn(ptr, &mut ag).await;
+            if let Err(err) = post_commit_fn(ptr, &mut ag).await {
+                indexed_errors.push((ag._index, err));
+                // don't break;
+            }
         }
-        ag.join_and_ignore_errors_async().await;
+        ag.join_and_collect_errors_async(&mut indexed_errors).await;
+
+        if !indexed_errors.is_empty() {
+            let mut errors = Vec::new();
+            for (i, err) in indexed_errors.into_iter() {
+                let report = &mut reports[i];
+                report.cause = TxnFailureCause::PostCommitFailure(err.clone());
+                errors.push((report.data_conn_name.clone(), err));
+            }
+            return Err(errs::Err::new(DataConnError::FailToPostCommitDataConn {
+                errors,
+            }));
+        }
 
         Ok(())
     }
 
-    pub(crate) async fn rollback_async(&mut self) {
+    pub(crate) async fn rollback_async(&mut self, mut reports: Vec<TxnFailureReport>) {
+        let mut indexed_errors = Vec::new();
+
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
-            let should_force_back_fn = unsafe { (*ptr).should_force_back_fn };
-            let force_back_fn = unsafe { (*ptr).force_back_fn };
+            let report = &mut reports[i];
+            let is_committed_fn = unsafe { (*ptr).is_committed_fn };
+            if is_committed_fn(ptr) {
+                if let TxnFailureCause::NoneByUncommitted = report.cause {
+                    report.cause = TxnFailureCause::NoneByCommitted;
+                }
+                continue;
+            }
             let rollback_fn = unsafe { (*ptr).rollback_fn };
             ag._index = i;
-
-            if should_force_back_fn(ptr) {
-                force_back_fn(ptr, &mut ag).await;
+            if let Err(err) = rollback_fn(ptr, &mut ag).await {
+                indexed_errors.push((ag._index, err));
             } else {
-                rollback_fn(ptr, &mut ag).await;
+                report.rollback = TxnFailureRollback::Success;
             }
+        }
+        ag.join_and_collect_errors_async(&mut indexed_errors).await;
+
+        if !indexed_errors.is_empty() {
+            for (i, err) in indexed_errors.into_iter() {
+                let report = &mut reports[i];
+                report.rollback = TxnFailureRollback::Failure(err);
+            }
+        }
+
+        let reports: Arc<[TxnFailureReport]> = Arc::from(reports);
+
+        let mut ag = AsyncGroup::new();
+        for ssnnptr in self.vec.iter().flatten() {
+            let ptr = ssnnptr.non_null_ptr.as_ptr();
+            let on_txn_failure_fn = unsafe { (*ptr).on_txn_failure_fn };
+            on_txn_failure_fn(ptr, &mut ag, reports.clone()).await;
         }
         ag.join_and_ignore_errors_async().await;
     }
@@ -307,7 +376,6 @@ impl DataConnManager {
         self.index_map.clear();
 
         let vec: Vec<Option<SendSyncNonNull<DataConnContainer>>> = mem::take(&mut self.vec);
-
         for ssnnptr in vec.iter().flatten() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let close_fn = unsafe { (*ptr).close_fn };
@@ -334,11 +402,16 @@ mod tests_of_data_conn {
     };
     use tokio::time;
 
+    const BASE_LINE: u32 = line!();
+
     #[derive(PartialEq, Copy, Clone)]
     enum Fail {
         Not,
         Commit,
         PreCommit,
+        PostCommit,
+        Rollback,
+        PreCommitBecomeCommitted,
     }
 
     struct SyncDataConn {
@@ -408,35 +481,50 @@ mod tests_of_data_conn {
                 .push(format!("SyncDataConn::pre_commit {}", id));
             Ok(())
         }
-        async fn post_commit_async(&mut self, _ag: &mut AsyncGroup) {
+        async fn post_commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+            let fail = self.fail;
             let id = self.id;
             let logger = self.logger.clone();
 
+            if fail == Fail::PostCommit {
+                logger
+                    .lock()
+                    .unwrap()
+                    .push(format!("SyncDataConn::post_commit {} failed", id));
+                return Err(errs::Err::new("!!!".to_string()));
+            }
             logger
                 .lock()
                 .unwrap()
                 .push(format!("SyncDataConn::post_commit {}", id));
+            Ok(())
         }
-        fn should_force_back(&self) -> bool {
+        fn is_committed(&self) -> bool {
             self.committed.load(Ordering::Acquire)
         }
-        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {
+        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+            let fail = self.fail;
             let id = self.id;
             let logger = self.logger.clone();
 
+            if fail == Fail::Rollback {
+                logger
+                    .lock()
+                    .unwrap()
+                    .push(format!("SyncDataConn::rollback {} failed", id));
+                return Err(errs::Err::new("!!!".to_string()));
+            }
             logger
                 .lock()
                 .unwrap()
                 .push(format!("SyncDataConn::rollback {}", id));
+            Ok(())
         }
-        async fn force_back_async(&mut self, _ag: &mut AsyncGroup) {
-            let id = self.id;
+        async fn on_txn_failure(&mut self, _ag: &mut AsyncGroup, reports: Arc<[TxnFailureReport]>) {
             let logger = self.logger.clone();
-
-            logger
-                .lock()
-                .unwrap()
-                .push(format!("SyncDataConn::force_back {}", id));
+            let mut logger = logger.lock().unwrap();
+            logger.push(format!("SyncDataConn::on_txn_failure {}", self.id));
+            logger.push(format!("TxnFailureReports={:?}", reports));
         }
         fn close(&mut self) {
             self.logger
@@ -480,7 +568,6 @@ mod tests_of_data_conn {
             let id = self.id;
             let logger = self.logger.clone();
             let committed = self.committed.clone();
-
             ag.add(async move {
                 time::sleep(time::Duration::from_millis(100)).await;
                 if fail == Fail::Commit {
@@ -503,7 +590,6 @@ mod tests_of_data_conn {
             let fail = self.fail;
             let id = self.id;
             let logger = self.logger.clone();
-
             ag.add(async move {
                 time::sleep(time::Duration::from_millis(100)).await;
                 if fail == Fail::PreCommit {
@@ -521,45 +607,60 @@ mod tests_of_data_conn {
             });
             Ok(())
         }
-        async fn post_commit_async(&mut self, ag: &mut AsyncGroup) {
+        async fn post_commit_async(&mut self, ag: &mut AsyncGroup) -> errs::Result<()> {
             let logger = self.logger.clone();
             let id = self.id;
-
+            let fail = self.fail;
             ag.add(async move {
                 time::sleep(time::Duration::from_millis(100)).await;
+                if fail == Fail::PostCommit {
+                    logger
+                        .lock()
+                        .unwrap()
+                        .push(format!("AsyncDataConn::post_commit {} failed", id));
+                    return Err(errs::Err::new("!!!".to_string()));
+                }
                 logger
                     .lock()
                     .unwrap()
                     .push(format!("AsyncDataConn::post_commit {}", id));
                 Ok(())
             });
+            Ok(())
         }
-        fn should_force_back(&self) -> bool {
+        fn is_committed(&self) -> bool {
             self.committed.load(Ordering::Acquire)
         }
-        async fn rollback_async(&mut self, ag: &mut AsyncGroup) {
+        async fn rollback_async(&mut self, ag: &mut AsyncGroup) -> errs::Result<()> {
             let logger = self.logger.clone();
             let id = self.id;
-
+            let fail = self.fail;
             ag.add(async move {
                 time::sleep(time::Duration::from_millis(100)).await;
+                if fail == Fail::Rollback {
+                    logger
+                        .lock()
+                        .unwrap()
+                        .push(format!("AsyncDataConn::rollback {} failed", id));
+                    return Err(errs::Err::new("???".to_string()));
+                }
                 logger
                     .lock()
                     .unwrap()
                     .push(format!("AsyncDataConn::rollback {}", id));
                 Ok(())
             });
+            Ok(())
         }
-        async fn force_back_async(&mut self, ag: &mut AsyncGroup) {
+        async fn on_txn_failure(&mut self, ag: &mut AsyncGroup, reports: Arc<[TxnFailureReport]>) {
+            let reports_log = format!("TxnFailureReports={:?}", reports);
             let logger = self.logger.clone();
             let id = self.id;
-
             ag.add(async move {
                 time::sleep(time::Duration::from_millis(100)).await;
-                logger
-                    .lock()
-                    .unwrap()
-                    .push(format!("AsyncDataConn::force_back {}", id));
+                let mut logger = logger.lock().unwrap();
+                logger.push(format!("AsyncDataConn::on_txn_failure {}", id));
+                logger.push(reports_log);
                 Ok(())
             });
         }
@@ -578,6 +679,7 @@ mod tests_of_data_conn {
         async fn test_new() {
             let manager = DataConnManager::new();
             assert!(manager.vec.is_empty());
+            assert!(manager.index_map.is_empty());
         }
 
         #[tokio::test]
@@ -792,8 +894,47 @@ mod tests_of_data_conn {
             }
         }
 
+        #[test]
+        fn test_new_failure_reports() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            let mut manager = DataConnManager::new();
+
+            let vec = manager.new_failure_reports();
+            assert_eq!(vec.len(), 0);
+
+            let conn = SyncDataConn::new(1, logger.clone(), Fail::Not);
+            let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+            let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+            let ssnnptr = SendSyncNonNull::new(nnptr);
+            manager.add(ssnnptr);
+
+            let conn = AsyncDataConn::new(2, logger.clone(), Fail::Not);
+            let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+            let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+            let ssnnptr = SendSyncNonNull::new(nnptr);
+            manager.add(ssnnptr);
+
+            let vec = manager.new_failure_reports();
+            assert_eq!(vec.len(), 2);
+
+            let report = &vec[0];
+            assert_eq!(report.data_conn_name, "foo".into());
+            assert_eq!(
+                report.data_conn_type,
+                "sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn"
+            );
+
+            let report = &vec[1];
+            assert_eq!(report.data_conn_name, "bar".into());
+            assert_eq!(
+                report.data_conn_type,
+                "sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn"
+            );
+        }
+
         #[tokio::test]
-        async fn test_commit_ok() {
+        async fn test_commit_and_rollback_ok() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -811,7 +952,9 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                assert!(manager.commit_async().await.is_ok());
+                let mut reports = manager.new_failure_reports();
+                assert!(manager.commit_async(&mut reports).await.is_ok());
+                manager.rollback_async(reports).await;
             }
 
             assert_eq!(
@@ -825,6 +968,10 @@ mod tests_of_data_conn {
                     "AsyncDataConn::commit 2",
                     "SyncDataConn::post_commit 1",
                     "AsyncDataConn::post_commit 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}]"),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}]"),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -834,7 +981,7 @@ mod tests_of_data_conn {
         }
 
         #[tokio::test]
-        async fn test_commit_with_order() {
+        async fn test_commit_with_order_and_rollback_ok() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -858,7 +1005,9 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                assert!(manager.commit_async().await.is_ok());
+                let mut reports = manager.new_failure_reports();
+                assert!(manager.commit_async(&mut reports).await.is_ok());
+                manager.rollback_async(reports).await;
             }
 
             assert_eq!(
@@ -869,13 +1018,19 @@ mod tests_of_data_conn {
                     "SyncDataConn::new 3",
                     "SyncDataConn::pre_commit 1",
                     "SyncDataConn::pre_commit 3",
-                    "AsyncDataConn::pre_commit 2", // because of async
+                    "AsyncDataConn::pre_commit 2",
                     "SyncDataConn::commit 1",
                     "SyncDataConn::commit 3",
-                    "AsyncDataConn::commit 2", // because of async
+                    "AsyncDataConn::commit 2",
                     "SyncDataConn::post_commit 1",
                     "SyncDataConn::post_commit 3",
-                    "AsyncDataConn::post_commit 2", // because of async
+                    "AsyncDataConn::post_commit 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"qux\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]"),
+                    "SyncDataConn::on_txn_failure 3",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"qux\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]"),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"qux\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]"),
                     "AsyncDataConn::close 2",
                     "AsyncDataConn::drop 2",
                     "SyncDataConn::close 1",
@@ -887,7 +1042,7 @@ mod tests_of_data_conn {
         }
 
         #[tokio::test]
-        async fn test_commit_but_fail_first_sync_pre_commit() {
+        async fn test_commit_and_rollback_but_fail_first_sync_pre_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -905,7 +1060,8 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                if let Err(e) = manager.commit_async().await {
+                let mut reports = manager.new_failure_reports();
+                if let Err(e) = manager.commit_async(&mut reports).await {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
@@ -917,14 +1073,41 @@ mod tests_of_data_conn {
                 } else {
                     panic!();
                 }
+                manager.rollback_async(reports).await;
             }
 
+            #[cfg(unix)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
                     "SyncDataConn::new 1",
                     "AsyncDataConn::new 2",
                     "SyncDataConn::pre_commit 1 failed",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 71),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 71),
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                ]
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "SyncDataConn::new 1",
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::pre_commit 1 failed",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 71),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 71),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -934,7 +1117,7 @@ mod tests_of_data_conn {
         }
 
         #[tokio::test]
-        async fn test_commit_but_fail_first_async_pre_commit() {
+        async fn test_commit_and_rollback_but_fail_first_async_pre_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -952,7 +1135,8 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                if let Err(e) = manager.commit_async().await {
+                let mut reports = manager.new_failure_reports();
+                if let Err(e) = manager.commit_async(&mut reports).await {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
@@ -964,24 +1148,45 @@ mod tests_of_data_conn {
                 } else {
                     panic!();
                 }
+                manager.rollback_async(reports).await;
             }
 
-            assert_eq!(
-                *logger.lock().unwrap(),
-                &[
-                    "SyncDataConn::new 1",
-                    "AsyncDataConn::new 2",
-                    "SyncDataConn::pre_commit 1 failed",
-                    "SyncDataConn::close 1",
-                    "SyncDataConn::drop 1",
-                    "AsyncDataConn::close 2",
-                    "AsyncDataConn::drop 2",
-                ]
-            );
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1 failed",
+                "SyncDataConn::rollback 1",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 71),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 71),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1 failed",
+                "SyncDataConn::rollback 1",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 71),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"zzz\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 71),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
         }
 
         #[tokio::test]
-        async fn test_commit_but_fail_second_pre_commit() {
+        async fn test_commit_and_rollback_but_fail_second_pre_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -999,7 +1204,8 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                if let Err(e) = manager.commit_async().await {
+                let mut reports = manager.new_failure_reports();
+                if let Err(e) = manager.commit_async(&mut reports).await {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
@@ -1011,6 +1217,7 @@ mod tests_of_data_conn {
                 } else {
                     panic!();
                 }
+                manager.rollback_async(reports).await;
             }
 
             assert_eq!(
@@ -1020,6 +1227,12 @@ mod tests_of_data_conn {
                     "SyncDataConn::new 2",
                     "SyncDataConn::pre_commit 2",
                     "AsyncDataConn::pre_commit 1 failed",
+                    "SyncDataConn::rollback 2",
+                    "AsyncDataConn::rollback 1",
+                    "SyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 195),
+                    "AsyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: RunFailure(errs::Err {{ reason = alloc::string::String \"yyy\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 195),
                     "AsyncDataConn::close 1",
                     "AsyncDataConn::drop 1",
                     "SyncDataConn::close 2",
@@ -1029,7 +1242,7 @@ mod tests_of_data_conn {
         }
 
         #[tokio::test]
-        async fn test_commit_but_fail_first_sync_commit() {
+        async fn test_commit_and_rollback_but_fail_first_sync_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -1047,7 +1260,8 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                if let Err(e) = manager.commit_async().await {
+                let mut reports = manager.new_failure_reports();
+                if let Err(e) = manager.commit_async(&mut reports).await {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
@@ -1059,8 +1273,10 @@ mod tests_of_data_conn {
                 } else {
                     panic!();
                 }
+                manager.rollback_async(reports).await;
             }
 
+            #[cfg(unix)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
@@ -1069,6 +1285,33 @@ mod tests_of_data_conn {
                     "SyncDataConn::pre_commit 1",
                     "AsyncDataConn::pre_commit 2",
                     "SyncDataConn::commit 1 failed",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 52),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 52),
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                ]
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "SyncDataConn::new 1",
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::pre_commit 1",
+                    "AsyncDataConn::pre_commit 2",
+                    "SyncDataConn::commit 1 failed",
+                    "SyncDataConn::rollback 1",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 52),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]", BASE_LINE + 52),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -1078,7 +1321,7 @@ mod tests_of_data_conn {
         }
 
         #[tokio::test]
-        async fn test_commit_but_fail_first_async_commit() {
+        async fn test_commit_and_rollback_but_fail_first_async_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -1096,7 +1339,8 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                if let Err(e) = manager.commit_async().await {
+                let mut reports = manager.new_failure_reports();
+                if let Err(e) = manager.commit_async(&mut reports).await {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
@@ -1108,8 +1352,10 @@ mod tests_of_data_conn {
                 } else {
                     panic!();
                 }
+                manager.rollback_async(reports).await;
             }
 
+            #[cfg(unix)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
@@ -1119,6 +1365,32 @@ mod tests_of_data_conn {
                     "AsyncDataConn::pre_commit 1",
                     "SyncDataConn::commit 2",
                     "AsyncDataConn::commit 1 failed",
+                    "AsyncDataConn::rollback 1",
+                    "SyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]", BASE_LINE + 173),
+                    "AsyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]", BASE_LINE + 173),
+                    "AsyncDataConn::close 1",
+                    "AsyncDataConn::drop 1",
+                    "SyncDataConn::close 2",
+                    "SyncDataConn::drop 2",
+                ]
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "AsyncDataConn::new 1",
+                    "SyncDataConn::new 2",
+                    "SyncDataConn::pre_commit 2",
+                    "AsyncDataConn::pre_commit 1",
+                    "SyncDataConn::commit 2",
+                    "AsyncDataConn::commit 1 failed",
+                    "AsyncDataConn::rollback 1",
+                    "SyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]", BASE_LINE + 173),
+                    "AsyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}]", BASE_LINE + 173),
                     "AsyncDataConn::close 1",
                     "AsyncDataConn::drop 1",
                     "SyncDataConn::close 2",
@@ -1128,7 +1400,7 @@ mod tests_of_data_conn {
         }
 
         #[tokio::test]
-        async fn test_commit_but_fail_second_commit() {
+        async fn test_commit_and_rollback_but_fail_second_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -1146,7 +1418,8 @@ mod tests_of_data_conn {
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                if let Err(e) = manager.commit_async().await {
+                let mut reports = manager.new_failure_reports();
+                if let Err(e) = manager.commit_async(&mut reports).await {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
@@ -1158,8 +1431,10 @@ mod tests_of_data_conn {
                 } else {
                     panic!();
                 }
+                manager.rollback_async(reports).await;
             }
 
+            #[cfg(unix)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
@@ -1169,43 +1444,32 @@ mod tests_of_data_conn {
                     "AsyncDataConn::pre_commit 2",
                     "SyncDataConn::commit 1",
                     "AsyncDataConn::commit 2 failed",
+                    "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
                     "AsyncDataConn::drop 2",
                 ]
             );
-        }
-
-        #[tokio::test]
-        async fn test_rollback_and_first_is_sync() {
-            let logger = Arc::new(Mutex::new(Vec::new()));
-
-            {
-                let mut manager = DataConnManager::new();
-
-                let conn = SyncDataConn::new(1, logger.clone(), Fail::Not);
-                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
-                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
-                let ssnnptr = SendSyncNonNull::new(nnptr);
-                manager.add(ssnnptr);
-
-                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Not);
-                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
-                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
-                let ssnnptr = SendSyncNonNull::new(nnptr);
-                manager.add(ssnnptr);
-
-                manager.rollback_async().await;
-            }
-
+            #[cfg(windows)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
                     "SyncDataConn::new 1",
                     "AsyncDataConn::new 2",
-                    "SyncDataConn::rollback 1",
+                    "SyncDataConn::pre_commit 1",
+                    "AsyncDataConn::pre_commit 2",
+                    "SyncDataConn::commit 1",
+                    "AsyncDataConn::commit 2 failed",
                     "AsyncDataConn::rollback 2",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -1215,65 +1479,43 @@ mod tests_of_data_conn {
         }
 
         #[tokio::test]
-        async fn test_rollback_and_first_is_async() {
+        async fn test_commit_and_rollback_but_fail_first_sync_post_commit() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
                 let mut manager = DataConnManager::new();
 
-                let conn = AsyncDataConn::new(1, logger.clone(), Fail::Not);
-                let boxed = Box::new(DataConnContainer::new("foo".to_string(), Box::new(conn)));
-                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
-                let ssnnptr = SendSyncNonNull::new(nnptr);
-                manager.add(ssnnptr);
-
-                let conn = SyncDataConn::new(2, logger.clone(), Fail::Not);
-                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
-                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
-                let ssnnptr = SendSyncNonNull::new(nnptr);
-                manager.add(ssnnptr);
-
-                manager.rollback_async().await;
-            }
-
-            assert_eq!(
-                *logger.lock().unwrap(),
-                &[
-                    "AsyncDataConn::new 1",
-                    "SyncDataConn::new 2",
-                    "SyncDataConn::rollback 2",
-                    "AsyncDataConn::rollback 1",
-                    "AsyncDataConn::close 1",
-                    "AsyncDataConn::drop 1",
-                    "SyncDataConn::close 2",
-                    "SyncDataConn::drop 2",
-                ]
-            );
-        }
-
-        #[tokio::test]
-        async fn test_force_back_and_first_is_sync() {
-            let logger = Arc::new(Mutex::new(Vec::new()));
-
-            {
-                let mut manager = DataConnManager::new();
-
-                let conn = SyncDataConn::new(1, logger.clone(), Fail::Not);
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::PostCommit);
                 let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
                 let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Not);
-                let boxed = Box::new(DataConnContainer::new("bar".to_string(), Box::new(conn)));
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::PostCommit);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
                 let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                assert!(manager.commit_async().await.is_ok());
-                manager.rollback_async().await;
+                let mut reports = manager.new_failure_reports();
+                if let Err(e) = manager.commit_async(&mut reports).await {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 2);
+                            assert_eq!(errors[0].0, "foo".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[1].0, "bar".into());
+                            assert_eq!(errors[1].1.reason::<String>().unwrap(), "!!!");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+                manager.rollback_async(reports).await;
             }
 
+            #[cfg(unix)]
             assert_eq!(
                 *logger.lock().unwrap(),
                 &[
@@ -1283,10 +1525,34 @@ mod tests_of_data_conn {
                     "AsyncDataConn::pre_commit 2",
                     "SyncDataConn::commit 1",
                     "AsyncDataConn::commit 2",
-                    "SyncDataConn::post_commit 1",
-                    "AsyncDataConn::post_commit 2",
-                    "SyncDataConn::force_back 1",
-                    "AsyncDataConn::force_back 2",
+                    "SyncDataConn::post_commit 1 failed",
+                    "AsyncDataConn::post_commit 2 failed",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89, BASE_LINE + 216),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89, BASE_LINE + 216),
+                    "SyncDataConn::close 1",
+                    "SyncDataConn::drop 1",
+                    "AsyncDataConn::close 2",
+                    "AsyncDataConn::drop 2",
+                ]
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                *logger.lock().unwrap(),
+                &[
+                    "SyncDataConn::new 1",
+                    "AsyncDataConn::new 2",
+                    "SyncDataConn::pre_commit 1",
+                    "AsyncDataConn::pre_commit 2",
+                    "SyncDataConn::commit 1",
+                    "AsyncDataConn::commit 2",
+                    "SyncDataConn::post_commit 1 failed",
+                    "AsyncDataConn::post_commit 2 failed",
+                    "SyncDataConn::on_txn_failure 1",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89, BASE_LINE + 216),
+                    "AsyncDataConn::on_txn_failure 2",
+                    &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89, BASE_LINE + 216),
                     "SyncDataConn::close 1",
                     "SyncDataConn::drop 1",
                     "AsyncDataConn::close 2",
@@ -1296,7 +1562,198 @@ mod tests_of_data_conn {
         }
 
         #[tokio::test]
-        async fn test_force_back_and_first_is_async() {
+        async fn test_commit_and_rollback_but_fail_first_async_post_commit() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::PostCommit);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::PostCommit);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let mut reports = manager.new_failure_reports();
+                if let Err(e) = manager.commit_async(&mut reports).await {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 2);
+                            assert_eq!(errors[0].0, "foo".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[1].0, "bar".into());
+                            assert_eq!(errors[1].1.reason::<String>().unwrap(), "!!!");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+                manager.rollback_async(reports).await;
+            }
+
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "AsyncDataConn::new 2",
+                "SyncDataConn::new 1",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1",
+                "AsyncDataConn::commit 2",
+                "SyncDataConn::post_commit 1 failed",
+                "AsyncDataConn::post_commit 2 failed",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = 610 }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = 610 }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89),
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "AsyncDataConn::new 2",
+                "SyncDataConn::new 1",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1",
+                "AsyncDataConn::commit 2",
+                "SyncDataConn::post_commit 1 failed",
+                "AsyncDataConn::post_commit 2 failed",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\tokio\\data_conn.rs, line = 610 }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\tokio\\data_conn.rs, line = 610 }}), rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89),
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+            ]);
+        }
+
+        #[tokio::test]
+        async fn test_commit_and_rollback_but_fail_second_post_commit() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Not);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::PostCommit);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let mut reports = manager.new_failure_reports();
+                if let Err(e) = manager.commit_async(&mut reports).await {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 1);
+                            assert_eq!(errors[0].0, "foo".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "!!!");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+                manager.rollback_async(reports).await;
+            }
+
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "AsyncDataConn::new 2",
+                "SyncDataConn::new 1",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1",
+                "AsyncDataConn::commit 2",
+                "SyncDataConn::post_commit 1 failed",
+                "AsyncDataConn::post_commit 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89),
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "AsyncDataConn::new 2",
+                "SyncDataConn::new 1",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1",
+                "AsyncDataConn::commit 2",
+                "SyncDataConn::post_commit 1 failed",
+                "AsyncDataConn::post_commit 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: PostCommitFailure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: None }}]", BASE_LINE + 89),
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+            ]);
+        }
+
+        #[tokio::test]
+        async fn test_only_rollback_and_first_is_sync() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::Not);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Not);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let reports = manager.new_failure_reports();
+                manager.rollback_async(reports).await;
+            }
+
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::rollback 1",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+        }
+
+        #[tokio::test]
+        async fn test_only_rollback_and_first_is_async() {
             let logger = Arc::new(Mutex::new(Vec::new()));
 
             {
@@ -1309,34 +1766,408 @@ mod tests_of_data_conn {
                 manager.add(ssnnptr);
 
                 let conn = SyncDataConn::new(2, logger.clone(), Fail::Not);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let reports = manager.new_failure_reports();
+                manager.rollback_async(reports).await;
+            }
+
+            assert_eq!(*logger.lock().unwrap(), &[
+                "AsyncDataConn::new 1",
+                "SyncDataConn::new 2",
+                "SyncDataConn::rollback 2",
+                "AsyncDataConn::rollback 1",
+                "SyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                "AsyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                "AsyncDataConn::close 1",
+                "AsyncDataConn::drop 1",
+                "SyncDataConn::close 2",
+                "SyncDataConn::drop 2",
+            ]);
+        }
+
+        #[tokio::test]
+        async fn test_only_rollback_and_second_rollback_failed() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = AsyncDataConn::new(1, logger.clone(), Fail::Not);
+                let boxed = Box::new(DataConnContainer::new("foo".to_string(), Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = SyncDataConn::new(2, logger.clone(), Fail::Rollback);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let reports = manager.new_failure_reports();
+                manager.rollback_async(reports).await;
+            }
+
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "AsyncDataConn::new 1",
+                "SyncDataConn::new 2",
+                "SyncDataConn::rollback 2 failed",
+                "AsyncDataConn::rollback 1",
+                "SyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}) }}]", BASE_LINE + 110),
+                "AsyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src/tokio/data_conn.rs, line = {} }}) }}]", BASE_LINE + 110),
+                "AsyncDataConn::close 1",
+                "AsyncDataConn::drop 1",
+                "SyncDataConn::close 2",
+                "SyncDataConn::drop 2",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "AsyncDataConn::new 1",
+                "SyncDataConn::new 2",
+                "SyncDataConn::rollback 2 failed",
+                "AsyncDataConn::rollback 1",
+                "SyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\tokio\\data_conn.rs, line = {} }}) }}]", BASE_LINE + 110),
+                "AsyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Success }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"!!!\", file = src\\tokio\\data_conn.rs, line = {} }}) }}]", BASE_LINE + 110),
+                "AsyncDataConn::close 1",
+                "AsyncDataConn::drop 1",
+                "SyncDataConn::close 2",
+                "SyncDataConn::drop 2",
+            ]);
+        }
+
+        #[tokio::test]
+        async fn test_only_rollback_and_first_rollback_failed() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = AsyncDataConn::new(1, logger.clone(), Fail::Rollback);
+                let boxed = Box::new(DataConnContainer::new("foo".to_string(), Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = SyncDataConn::new(2, logger.clone(), Fail::Not);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let reports = manager.new_failure_reports();
+                manager.rollback_async(reports).await;
+            }
+
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "AsyncDataConn::new 1",
+                "SyncDataConn::new 2",
+                "SyncDataConn::rollback 2",
+                "AsyncDataConn::rollback 1 failed",
+                "SyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/tokio/data_conn.rs, line = 634 }}) }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                "AsyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/tokio/data_conn.rs, line = 634 }}) }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                "AsyncDataConn::close 1",
+                "AsyncDataConn::drop 1",
+                "SyncDataConn::close 2",
+                "SyncDataConn::drop 2",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "AsyncDataConn::new 1",
+                "SyncDataConn::new 2",
+                "SyncDataConn::rollback 2",
+                "AsyncDataConn::rollback 1 failed",
+                "SyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src\\tokio\\data_conn.rs, line = 634 }}) }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                "AsyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src\\tokio\\data_conn.rs, line = 634 }}) }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByUncommitted, rollback: Success }}]"),
+                "AsyncDataConn::close 1",
+                "AsyncDataConn::drop 1",
+                "SyncDataConn::close 2",
+                "SyncDataConn::drop 2",
+            ]);
+        }
+
+        #[tokio::test]
+        async fn test_commit_and_rollback_and_first_commit_failed_and_second_rollback_failed() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::Commit);
+                let boxed = Box::new(DataConnContainer::new("bar", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Rollback);
+                let boxed = Box::new(DataConnContainer::new("foo".to_string(), Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let mut reports = manager.new_failure_reports();
+
+                if let Err(e) = manager.commit_async(&mut reports).await {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 1);
+                            assert_eq!(errors[0].0, "bar".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "ZZZ");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+
+                manager.rollback_async(reports).await;
+            }
+
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1 failed",
+                "SyncDataConn::rollback 1",
+                "AsyncDataConn::rollback 2 failed",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/tokio/data_conn.rs, line = {} }}) }}]", BASE_LINE + 52, BASE_LINE + 240),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src/tokio/data_conn.rs, line = {} }}) }}]", BASE_LINE + 52, BASE_LINE + 240),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1 failed",
+                "SyncDataConn::rollback 1",
+                "AsyncDataConn::rollback 2 failed",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src\\tokio\\data_conn.rs, line = {} }}) }}]", BASE_LINE + 52, BASE_LINE + 240),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"ZZZ\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}, TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByUncommitted, rollback: Failure(errs::Err {{ reason = alloc::string::String \"???\", file = src\\tokio\\data_conn.rs, line = {} }}) }}]", BASE_LINE + 52, BASE_LINE + 240),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+        }
+
+        #[tokio::test]
+        async fn test_commit_and_rollback_and_secod_commit_failed_and_first_rollback_failed() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::Rollback);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Commit);
                 let boxed = Box::new(DataConnContainer::new("bar".to_string(), Box::new(conn)));
                 let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
                 let ssnnptr = SendSyncNonNull::new(nnptr);
                 manager.add(ssnnptr);
 
-                assert!(manager.commit_async().await.is_ok());
-                manager.rollback_async().await;
+                let mut reports = manager.new_failure_reports();
+
+                if let Err(e) = manager.commit_async(&mut reports).await {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 1);
+                            assert_eq!(errors[0].0, "bar".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "YYY");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+
+                manager.rollback_async(reports).await;
             }
 
-            assert_eq!(
-                *logger.lock().unwrap(),
-                &[
-                    "AsyncDataConn::new 1",
-                    "SyncDataConn::new 2",
-                    "SyncDataConn::pre_commit 2",
-                    "AsyncDataConn::pre_commit 1",
-                    "SyncDataConn::commit 2",
-                    "AsyncDataConn::commit 1",
-                    "SyncDataConn::post_commit 2",
-                    "AsyncDataConn::post_commit 1",
-                    "SyncDataConn::force_back 2",
-                    "AsyncDataConn::force_back 1",
-                    "AsyncDataConn::close 1",
-                    "AsyncDataConn::drop 1",
-                    "SyncDataConn::close 2",
-                    "SyncDataConn::drop 2",
-                ]
-            );
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1",
+                "AsyncDataConn::commit 2 failed",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1",
+                "AsyncDataConn::commit 2 failed",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+        }
+
+        #[tokio::test]
+        async fn test_commit_and_rollback_and_pre_commit_become_committed_and_ok() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::PreCommitBecomeCommitted);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::PreCommitBecomeCommitted);
+                let boxed = Box::new(DataConnContainer::new("bar".to_string(), Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let mut reports = manager.new_failure_reports();
+                assert!(manager.commit_async(&mut reports).await.is_ok());
+                manager.rollback_async(reports).await;
+            }
+
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1",
+                "AsyncDataConn::commit 2",
+                "SyncDataConn::post_commit 1",
+                "AsyncDataConn::post_commit 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}]"),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: NoneByCommitted, rollback: None }}]"),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+        }
+
+        #[tokio::test]
+        async fn test_commit_and_rollback_and_pre_commit_become_committed_but_failed() {
+            let logger = Arc::new(Mutex::new(Vec::new()));
+
+            {
+                let mut manager = DataConnManager::new();
+
+                let conn = SyncDataConn::new(1, logger.clone(), Fail::PreCommitBecomeCommitted);
+                let boxed = Box::new(DataConnContainer::new("foo", Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let conn = AsyncDataConn::new(2, logger.clone(), Fail::Commit);
+                let boxed = Box::new(DataConnContainer::new("bar".to_string(), Box::new(conn)));
+                let nnptr = ptr::NonNull::from(Box::leak(boxed)).cast::<DataConnContainer>();
+                let ssnnptr = SendSyncNonNull::new(nnptr);
+                manager.add(ssnnptr);
+
+                let mut reports = manager.new_failure_reports();
+
+                if let Err(e) = manager.commit_async(&mut reports).await {
+                    match e.reason::<DataConnError>() {
+                        Ok(DataConnError::FailToCommitDataConn { errors }) => {
+                            assert_eq!(errors.len(), 1);
+                            assert_eq!(errors[0].0, "bar".into());
+                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "YYY");
+                        }
+                        _ => panic!(),
+                    }
+                } else {
+                    panic!();
+                }
+
+                manager.rollback_async(reports).await;
+            }
+
+            #[cfg(unix)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1",
+                "AsyncDataConn::commit 2 failed",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src/tokio/data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
+            #[cfg(windows)]
+            assert_eq!(*logger.lock().unwrap(), &[
+                "SyncDataConn::new 1",
+                "AsyncDataConn::new 2",
+                "SyncDataConn::pre_commit 1",
+                "AsyncDataConn::pre_commit 2",
+                "SyncDataConn::commit 1",
+                "AsyncDataConn::commit 2 failed",
+                "AsyncDataConn::rollback 2",
+                "SyncDataConn::on_txn_failure 1",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                "AsyncDataConn::on_txn_failure 2",
+                &format!("TxnFailureReports=[TxnFailureReport {{ data_conn_name: \"foo\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::SyncDataConn\", cause: NoneByCommitted, rollback: None }}, TxnFailureReport {{ data_conn_name: \"bar\", data_conn_type: \"sabi::tokio::data_conn::tests_of_data_conn::AsyncDataConn\", cause: CommitFailure(errs::Err {{ reason = alloc::string::String \"YYY\", file = src\\tokio\\data_conn.rs, line = {} }}), rollback: Success }}]", BASE_LINE + 173),
+                "SyncDataConn::close 1",
+                "SyncDataConn::drop 1",
+                "AsyncDataConn::close 2",
+                "AsyncDataConn::drop 2",
+            ]);
         }
     }
 }

--- a/src/tokio/data_hub.rs
+++ b/src/tokio/data_hub.rs
@@ -26,6 +26,7 @@ pub enum DataHubError {
     NoDataSrcToCreateDataConn {
         /// The name of the data connection that could not be created.
         name: Arc<str>,
+
         /// The string representation of the data connection type that was requested.
         data_conn_type: &'static str,
     },
@@ -55,9 +56,10 @@ impl DataHub {
     /// not specified in `names` will be committed after the specified ones, in an undefined order.
     /// Global data sources are copied into the `data_src_map`.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
-    /// * `names` - An array of string slices specifying the desired commit order by data connection name.
+    /// * `names` - An array of string slices specifying the desired commit order by data connection
+    ///   name.
     pub fn with_commit_order(names: &[&str]) -> Self {
         let mut data_src_map = HashMap::new();
         copy_global_data_srcs_to_map(&mut data_src_map);
@@ -75,11 +77,11 @@ impl DataHub {
     /// This method allows adding a custom data source which can provide data connections.
     /// Data sources can only be added before `run_async` or `txn_async` are called.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
     /// * `name` - The name to associate with this data source.
-    /// * `ds` - The data source instance, which must implement `DataSrc` and have a `'static` lifetime.
-    ///   If this `DataHub` is moved between threads, `ds` must also implement `Send`.
+    /// * `ds` - The data source instance, which must implement `DataSrc` and have a `'static`
+    ///   lifetime. If this `DataHub` is moved between threads, `ds` must also implement `Send`.
     ///
     /// # Type Parameters
     ///
@@ -101,7 +103,7 @@ impl DataHub {
     /// This removes a data source previously added with `uses`. Data sources can only be
     /// removed before `run_async` or `txn_async` are called.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
     /// * `name` - The name of the data source to remove.
     pub fn disuses(&mut self, name: impl AsRef<str>) {
@@ -131,16 +133,6 @@ impl DataHub {
     }
 
     #[inline]
-    async fn commit_async(&mut self) -> errs::Result<()> {
-        self.data_conn_manager.commit_async().await
-    }
-
-    #[inline]
-    async fn rollback_async(&mut self) {
-        self.data_conn_manager.rollback_async().await
-    }
-
-    #[inline]
     fn end(&mut self) {
         self.data_conn_manager.close();
         self.fixed = false;
@@ -152,7 +144,7 @@ impl DataHub {
     /// cleans up all data connections and sources. It does *not* automatically commit
     /// or rollback any transactions.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
     /// * `logic_fn` - An asynchronous function that takes a mutable reference to `DataHub`
     ///                and returns a `Result`. This function contains the application's logic.
@@ -180,19 +172,21 @@ impl DataHub {
         r
     }
 
-    /// Executes an asynchronous transactional logic function with the `DataHub`, managing
-    /// setup, commit, and rollback for data connections.
+    /// Executes a given asynchronous logic function within a managed transaction.
     ///
-    /// This method sets up local data sources, runs the provided `logic_fn`. If the logic
-    /// function succeeds, it attempts to commit all created data connections. If either
-    /// the logic function or the commit fails, it rolls back all data connections.
-    /// Finally, it cleans up all data connections and sources.
+    /// This method starts by asynchronously setting up local data sources, runs the provided closure,
+    /// and then attempts to asynchronously commit all open data connections in the session.
     ///
-    /// # Arguments
+    /// If any error occurs during the execution of the closure or during the commit phase,
+    /// it initiates an asynchronous rollback on all data connections and reports the transaction
+    /// failure details.
+    /// Finally, it cleans up session resources.
     ///
-    /// * `logic_fn` - An asynchronous function that takes a mutable reference to `DataHub`
-    ///                and returns a `Result`. This function contains the application's transactional logic.
-    ///                The returned `Future` must implement `Send`.
+    /// # Parameters
+    ///
+    /// * `logic_fn`: An asynchronous closure that encapsulates the business logic to be executed.
+    ///   It takes a mutable reference to [`DataHub`] as an argument and returns a pinned, boxed
+    ///   future.
     ///
     /// # Type Parameters
     ///
@@ -200,8 +194,8 @@ impl DataHub {
     ///
     /// # Returns
     ///
-    /// A `Result` indicating the success or failure of the `logic_fn` execution,
-    /// the setup of data sources, or the commit/rollback operations.
+    /// * `errs::Result<()>`: `Ok(())` if the closure and the commit phase succeed,
+    ///   or an [`errs::Err`] if any phase fails.
     #[allow(clippy::doc_overindented_list_items)]
     pub async fn txn_async<F>(&mut self, mut logic_fn: F) -> errs::Result<()>
     where
@@ -212,12 +206,16 @@ impl DataHub {
         if r.is_ok() {
             r = logic_fn(self).await;
         }
+
+        let mut reports = self.data_conn_manager.new_failure_reports();
+
         if r.is_ok() {
-            r = self.commit_async().await;
+            r = self.data_conn_manager.commit_async(&mut reports).await;
         }
         if r.is_err() {
-            self.rollback_async().await;
+            self.data_conn_manager.rollback_async(reports).await;
         }
+
         self.end();
         r
     }
@@ -228,13 +226,14 @@ impl DataHub {
     /// and type `C` already exists. If not, it attempts to find a suitable data source
     /// (local or global) to create a new data connection.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
     /// * `name` - The name of the data connection to retrieve or create.
     ///
     /// # Type Parameters
     ///
-    /// * `C` - The expected type of the data connection, which must implement `DataConn` and have a `'static` lifetime.
+    /// * `C` - The expected type of the data connection, which must implement `DataConn` and have
+    ///   a `'static` lifetime.
     ///
     /// # Returns
     ///
@@ -294,6 +293,7 @@ macro_rules! _logic {
 mod tests_of_data_hub {
     use super::*;
     use crate::tokio::AsyncGroup;
+    use crate::TxnFailureReport;
     use std::sync::Mutex;
 
     #[derive(Clone, Copy, PartialEq)]
@@ -365,23 +365,32 @@ mod tests_of_data_hub {
                 Ok(())
             }
         }
-        async fn post_commit_async(&mut self, _ag: &mut AsyncGroup) {
+        async fn post_commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             self.logger
                 .lock()
                 .unwrap()
                 .push(format!("MyDataConn::post_commit {}", self.id));
+            Ok(())
         }
-        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {
+        fn is_committed(&self) -> bool {
+            self.committed
+        }
+        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             self.logger
                 .lock()
                 .unwrap()
                 .push(format!("MyDataConn::rollback {}", self.id));
+            Ok(())
         }
-        async fn force_back_async(&mut self, _ag: &mut AsyncGroup) {
+        async fn on_txn_failure(
+            &mut self,
+            _ag: &mut AsyncGroup,
+            _reports: Arc<[TxnFailureReport]>,
+        ) {
             self.logger
                 .lock()
                 .unwrap()
-                .push(format!("MyDataConn::force_back {}", self.id));
+                .push(format!("MyDataConn::on_txn_failure {}", self.id));
         }
         fn close(&mut self) {
             self.logger
@@ -1047,6 +1056,8 @@ mod tests_of_data_hub {
                 "MyDataConn::new 2",
                 "MyDataConn::rollback 1",
                 "MyDataConn::rollback 2",
+                "MyDataConn::on_txn_failure 1",
+                "MyDataConn::on_txn_failure 2",
                 "MyDataConn::close 1",
                 "MyDataConn::drop 1",
                 "MyDataConn::close 2",

--- a/src/tokio/data_hub.rs
+++ b/src/tokio/data_hub.rs
@@ -382,7 +382,7 @@ mod tests_of_data_hub {
                 .push(format!("MyDataConn::rollback {}", self.id));
             Ok(())
         }
-        async fn on_txn_failure(
+        async fn on_txn_failure_async(
             &mut self,
             _ag: &mut AsyncGroup,
             _reports: Arc<[TxnFailureReport]>,

--- a/src/tokio/data_src/global_setup.rs
+++ b/src/tokio/data_src/global_setup.rs
@@ -33,11 +33,14 @@ impl Drop for AutoShutdown {
 
 /// Registers a global data source, making it available throughout the application.
 ///
-/// Global data sources are managed by a singleton and can be set up once for the application's lifetime.
-/// If `setup_async` or `setup_with_order_async` has already been called, this function will return an `errs::Err`.
-/// If another Tokio task holds the lock of the global data source manager, this function will wait until the lock is released.
+/// Global data sources are managed by a singleton and can be set up once for the application's
+/// lifetime.
+/// If `setup_async` or `setup_with_order_async` has already been called, this function will return
+/// an `errs::Err`.
+/// If another Tokio task holds the lock of the global data source manager, this function will wait
+/// until the lock is released.
 ///
-/// # Arguments
+/// # Parameters
 ///
 /// * `name` - The name to associate with this data source.
 /// * `ds` - The data source instance, which must implement `DataSrc` and have a `'static` lifetime.
@@ -71,11 +74,14 @@ where
 /// Registers a global data source, making it available throughout the application.
 ///
 /// This is the synchronous version of `uses_async`.
-/// Global data sources are managed by a singleton and can be set up once for the application's lifetime.
-/// If `setup_async` or `setup_with_order_async` has already been called, this function will return an `errs::Err`.
-/// If another Tokio task holds the lock of the global data source manager, this function will return an error immediately without waiting.
+/// Global data sources are managed by a singleton and can be set up once for the application's
+/// lifetime.
+/// If `setup_async` or `setup_with_order_async` has already been called, this function will return
+/// an `errs::Err`.
+/// If another Tokio task holds the lock of the global data source manager, this function will return
+/// an error immediately without waiting.
 ///
-/// # Arguments
+/// # Parameters
 ///
 /// * `name` - The name to associate with this data source.
 /// * `ds` - The data source instance, which must implement `DataSrc` and have a `'static` lifetime.
@@ -171,7 +177,7 @@ pub async fn setup_async() -> errs::Result<AutoShutdown> {
 /// are set up. Data sources not specified in `names` will be set up after the
 /// specified ones, in an undefined order.
 ///
-/// # Arguments
+/// # Parameters
 ///
 /// * `names` - An array of string slices specifying the desired setup order by data source name.
 ///

--- a/src/tokio/data_src/mod.rs
+++ b/src/tokio/data_src/mod.rs
@@ -48,6 +48,7 @@ pub enum DataSrcError {
     FailToCastDataConn {
         /// The name of the data source that failed to provide the correct connection type.
         name: Arc<str>,
+
         /// The string representation of the target data connection type that was requested.
         target_type: &'static str,
     },
@@ -56,6 +57,7 @@ pub enum DataSrcError {
     FailToCreateDataConn {
         /// The name of the data source that failed to create a data connection.
         name: Arc<str>,
+
         /// The string representation of the data connection type that was requested.
         data_conn_type: &'static str,
     },
@@ -64,6 +66,7 @@ pub enum DataSrcError {
     NotFoundDataSrcToCreateDataConn {
         /// The name of the data source that was not found.
         name: Arc<str>,
+
         /// The string representation of the data connection type that was requested.
         data_conn_type: &'static str,
     },
@@ -399,7 +402,12 @@ mod tests_of_data_src {
         async fn commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             Ok(())
         }
-        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {}
+        fn is_committed(&self) -> bool {
+            false
+        }
+        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+            Ok(())
+        }
         fn close(&mut self) {}
     }
 
@@ -413,7 +421,12 @@ mod tests_of_data_src {
         async fn commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
             Ok(())
         }
-        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {}
+        fn is_committed(&self) -> bool {
+            false
+        }
+        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+            Ok(())
+        }
         fn close(&mut self) {}
     }
 

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -173,7 +173,7 @@ pub trait DataConn {
     /// * `ag`: A mutable reference to an [`AsyncGroup`] for asynchronous task execution.
     /// * `reports`: An [`Arc`] slice of [`TxnFailureReport`] containing failure details for all
     ///   connections.
-    fn on_txn_failure(
+    fn on_txn_failure_async(
         &mut self,
         ag: &mut AsyncGroup,
         reports: Arc<[TxnFailureReport]>,

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -16,7 +16,7 @@ mod data_conn;
 mod data_hub;
 mod data_src;
 
-use crate::SendSyncNonNull;
+use crate::{SendSyncNonNull, TxnFailureReport};
 
 use std::any;
 use std::collections::HashMap;
@@ -56,7 +56,7 @@ pub use crate::_logic as logic;
 
 /// Macro for registering a global data source at the top-level.
 ///
-/// # Arguments
+/// # Parameters
 ///
 /// * `$name` - The name of the data source (must be a string literal).
 /// * `$data_src` - The data source instance.
@@ -69,8 +69,12 @@ pub use crate::_logic as logic;
 #[doc(inline)]
 pub use crate::_uses_for_async as uses;
 
-/// Manages a collection of asynchronous tasks, allowing them to be executed concurrently
-/// and their results (or errors) collected.
+/// The structure that allows for the concurrent execution of multiple asynchronous tasks
+/// using green-thread and waits for all of them to complete.
+///
+/// Functions are added using the `add` method and are then run concurrently in separate green-threads.
+/// The `AsyncGroup` ensures that all tasks finish before proceeding,
+/// and can collect any errors that occur.
 #[allow(clippy::type_complexity)]
 pub struct AsyncGroup {
     indexes: Vec<usize>,
@@ -78,18 +82,19 @@ pub struct AsyncGroup {
     _index: usize,
 }
 
-/// A trait for data connection implementations, providing methods for transaction management.
+/// The asynchronous trait for data connection implementations, providing methods for transaction
+/// management.
 ///
 /// Implementors of this trait represent a connection to a data source and define
 /// how to commit, rollback, and handle the lifecycle of transactions.
 #[allow(async_fn_in_trait)]
 #[allow(unused_variables)] // rustdoc
 pub trait DataConn {
-    /// Attempts to commit the changes made within this data connection.
+    /// Attempts to asynchronously commit the changes made within this data connection.
     ///
     /// This is typically the main commit process, executed after `pre_commit_async`.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
     /// * `ag` - An `AsyncGroup` to which asynchronous tasks related to the commit can be added.
     ///
@@ -106,7 +111,7 @@ pub trait DataConn {
     /// This method is called before `commit_async` and can be used for tasks like
     /// validation or preparing data.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
     /// * `ag` - An `AsyncGroup` to which asynchronous tasks related to pre-commit can be added.
     ///
@@ -122,49 +127,57 @@ pub trait DataConn {
 
     /// Performs actions after the main commit process, only if it succeeds.
     ///
-    /// This can be used for cleanup or post-transaction logging. Errors returned from
-    /// tasks added to `ag` in this method are ignored.
+    /// This can be used for cleanup or post-transaction logging.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
     /// * `ag` - An `AsyncGroup` to which asynchronous tasks related to post-commit can be added.
-    fn post_commit_async(&mut self, ag: &mut AsyncGroup) -> impl Future<Output = ()> + Send {
-        async {}
-    }
-
-    /// Indicates whether `force_back_async` should be called instead of `rollback_async`.
-    ///
-    /// This is typically `true` if `commit_async` has already succeeded for this connection,
-    /// implying that changes need to be undone rather than simply discarded.
     ///
     /// # Returns
     ///
-    /// `true` if `force_back_async` should be called, `false` otherwise.
-    fn should_force_back(&self) -> bool {
-        false
+    /// A `Result` indicating success or failure of the post-commit operation.
+    fn post_commit_async(
+        &mut self,
+        ag: &mut AsyncGroup,
+    ) -> impl Future<Output = errs::Result<()>> + Send {
+        async { Ok(()) }
     }
 
-    /// Rolls back any changes made within this data connection.
+    /// Returns whether the transaction on this connection has been successfully committed.
+    fn is_committed(&self) -> bool;
+
+    /// Rolls back any changes made within this data connection's transaction.
     ///
-    /// This method is called if a transaction fails before `commit_async` completes,
-    /// or if `should_force_back` returns `false`. Errors returned from tasks added to `ag`
-    /// in this method are ignored.
+    /// This method undoes all operations performed since the beginning of the transaction,
+    /// restoring the data service to its state before the transaction began.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
     /// * `ag` - An `AsyncGroup` to which asynchronous tasks related to rollback can be added.
-    fn rollback_async(&mut self, ag: &mut AsyncGroup) -> impl Future<Output = ()> + Send;
+    ///
+    /// # Returns
+    ///
+    /// A `Result` indicating success or failure of the rollback operation.
+    fn rollback_async(
+        &mut self,
+        ag: &mut AsyncGroup,
+    ) -> impl Future<Output = errs::Result<()>> + Send;
 
-    /// Forces the data connection to revert changes that have already been committed.
+    /// An asynchronous lifecycle callback invoked when a transaction fails and a rollback is executed.
     ///
-    /// This method is called if a transaction fails after `commit_async` has completed
-    /// for this connection, and `should_force_back` returns `true`. Errors returned from
-    /// tasks added to `ag` in this method are ignored.
+    /// This allows the data connection to handle post-failure tasks or custom logic
+    /// based on the provided transaction failure reports.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
-    /// * `ag` - An `AsyncGroup` to which asynchronous tasks related to force-back can be added.
-    fn force_back_async(&mut self, ag: &mut AsyncGroup) -> impl Future<Output = ()> + Send {
+    /// * `ag`: A mutable reference to an [`AsyncGroup`] for asynchronous task execution.
+    /// * `reports`: An [`Arc`] slice of [`TxnFailureReport`] containing failure details for all
+    ///   connections.
+    fn on_txn_failure(
+        &mut self,
+        ag: &mut AsyncGroup,
+        reports: Arc<[TxnFailureReport]>,
+    ) -> impl Future<Output = ()> + Send {
         async {}
     }
 
@@ -180,7 +193,12 @@ impl DataConn for NoopDataConn {
     async fn commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
         Ok(())
     }
-    async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {}
+    fn is_committed(&self) -> bool {
+        false
+    }
+    async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+        Ok(())
+    }
     fn close(&mut self) {}
 }
 
@@ -192,6 +210,7 @@ where
 {
     drop_fn: fn(*const DataConnContainer),
     is_fn: fn(any::TypeId) -> bool,
+    type_fn: fn() -> &'static str,
 
     commit_fn: for<'ag> fn(
         *const DataConnContainer,
@@ -206,18 +225,20 @@ where
     post_commit_fn: for<'ag> fn(
         *const DataConnContainer,
         &'ag mut AsyncGroup,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'ag>>,
+    )
+        -> Pin<Box<dyn Future<Output = errs::Result<()>> + Send + 'ag>>,
 
-    should_force_back_fn: fn(*const DataConnContainer) -> bool,
+    is_committed_fn: fn(*const DataConnContainer) -> bool,
 
     rollback_fn: for<'ag> fn(
         *const DataConnContainer,
         &'ag mut AsyncGroup,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'ag>>,
+    ) -> Pin<Box<dyn Future<Output = errs::Result<()>> + Send + 'ag>>,
 
-    force_back_fn: for<'ag> fn(
+    on_txn_failure_fn: for<'ag> fn(
         *const DataConnContainer,
         &'ag mut AsyncGroup,
+        Arc<[TxnFailureReport]>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'ag>>,
 
     close_fn: fn(*const DataConnContainer),
@@ -231,41 +252,50 @@ pub(crate) struct DataConnManager {
     index_map: HashMap<Arc<str>, usize>,
 }
 
-/// A trait for data source implementations, responsible for setting up and creating data connections.
+/// The trait that abstracts a data source responsible for managing connections
+/// to external data services, such as databases, file systems, or messaging services.
 ///
-/// Implementors of this trait define how to prepare a data source and how to instantiate
-/// data connections of a specific type `C`.
+/// It receives configuration for connecting to an external data service and then
+/// creates and supplies [`DataConn`] instance, representing a single session connection.
 #[trait_variant::make(Send)]
 #[allow(unused_variables)] // for rustdoc
 pub trait DataSrc<C>
 where
     C: DataConn + 'static,
 {
-    /// Performs asynchronous setup operations for the data source.
+    /// Performs the asynchronous setup process for the data source.
     ///
-    /// This method is called to initialize the data source before any data connections
-    /// are created from it.
+    /// This method is responsible for establishing global connections, configuring
+    /// connection pools, or performing any necessary initializations required
+    /// before [`DataConn`] instances can be created.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
-    /// * `ag` - An `AsyncGroup` to which asynchronous setup tasks can be added.
+    /// * `ag`: A mutable reference to an [`AsyncGroup`]. This is used if the setup
+    ///   process is potentially time-consuming and can benefit from concurrent
+    ///   execution in a separate thread.
     ///
     /// # Returns
     ///
-    /// A `Result` indicating success or failure of the setup operation.
+    /// * `errs::Result<()>`: `Ok(())` if the setup is successful, or an [`errs::Err`]
+    ///   if any part of the setup fails.
     async fn setup_async(&mut self, ag: &mut AsyncGroup) -> errs::Result<()>;
 
-    /// Closes the data source, releasing any associated resources.
+    /// Closes the data source and releases any globally held resources.
     ///
-    /// This method is always called at the end of the `DataHub`'s lifecycle for this source.
+    /// This method should perform cleanup operations, such as closing global connections
+    /// or shutting down connection pools, that were established during the setup process.
     fn close(&mut self);
 
-    /// Asynchronously creates a new data connection from this data source.
+    /// Asynchronously creates a new [`DataConn`] instance which is a connection per session.
+    ///
+    /// Each call to this method should yield a distinct [`DataConn`] object tailored
+    /// for a single session's operations.
     ///
     /// # Returns
     ///
-    /// A `Result` which is `Ok` containing a `Box`ed instance of the data connection `C`,
-    /// or an `Err` if the connection creation fails.
+    /// * `errs::Result<Box<C>>`: `Ok(Box<C>)` containing the newly created [`DataConn`]
+    ///   if successful, or an [`errs::Err`] if the connection could not be created.
     async fn create_data_conn_async(&mut self) -> errs::Result<Box<C>>;
 }
 
@@ -314,16 +344,27 @@ pub(crate) struct DataSrcManager {
     local: bool,
 }
 
-/// A marker struct that can be used to trigger automatic shutdown behavior
-/// for resources managed by the `DataHub` when it goes out of scope.
+/// A utility struct that ensures to close and drop global data sources when it goes out of scope.
+///
+/// This struct implements the `Drop` trait, and its `drop` method handles the closing and
+/// dropping of registered global data sources.
+/// Therefore, this ensures that these operations are automatically executed at the end of
+/// the scope.
+///
+/// **NOTE:** Do not receive an instance of this struct into an anonymous variable
+/// (`let _ = ...`), because an anonymous variable is dropped immediately at that point.
 pub struct AutoShutdown {}
 
-/// The central hub for managing data sources and their connections within an application.
+/// The struct that acts as a central hub for data input/output operations, integrating
+/// multiple *Data* traits (which are passed to business logic functions as their arguments) with
+/// [`DataAcc`] traits (which implement default data I/O methods for external services).
 ///
-/// `DataHub` provides mechanisms to register data sources, acquire data connections,
-/// and execute transactional or non-transactional asynchronous logic.
+/// It facilitates data access by providing [`DataConn`] objects, created from
+/// both global data sources (registered via the global [`uses!`] macro) and
+/// session-local data sources (registered via [`DataHub::uses`] method).
 ///
-/// This structure implements `Send`.
+/// The [`DataHub`] is capable of performing aggregated transactional operations
+/// on all [`DataConn`] objects created from its registered [`DataSrc`] instances.
 pub struct DataHub {
     local_data_src_manager: DataSrcManager,
     data_src_map: HashMap<Arc<str>, (bool, usize)>,
@@ -331,25 +372,33 @@ pub struct DataHub {
     fixed: bool,
 }
 
-/// A trait defining the ability to access data connections.
+/// This trait provides a mechanism to retrieve a mutable reference to a [`DataConn`] object
+/// by name, creating it if necessary.
 ///
-/// This trait abstracts the mechanism for retrieving data connections, allowing
-/// different implementations (e.g., `DataHub`) to provide connections.
+/// It is typically implemented as a derived trait with default methods (using
+/// the `override_macro` crate) on [`DataHub`], allowing application logic to
+/// interact with data services through an abstract interface.
 pub trait DataAcc {
-    /// Asynchronously retrieves a data connection of a specific type.
+    /// Retrieves a mutable reference to a [`DataConn`] object by name, creating it if necessary.
+    ///
+    /// This is the core method used by [`DataAcc`] implementations to obtain connections
+    /// to external data services. It first checks if a [`DataConn`] with the given name
+    /// already exists in the current session. If not, it attempts to find a
+    /// corresponding [`DataSrc`] and create a new [`DataConn`] from it.
     ///
     /// # Type Parameters
     ///
-    /// * `C` - The expected type of the data connection, which must implement `DataConn` and have a `'static` lifetime.
+    /// * `C`: The concrete type of [`DataConn`] expected.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
-    /// * `name` - The name of the data connection to retrieve.
+    /// * `name`: The name of the data source/connection to retrieve.
     ///
     /// # Returns
     ///
-    /// A `Result` which is `Ok` containing a mutable reference to the data connection
-    /// if found, or an `Err` if the connection cannot be retrieved or cast.
+    /// * `errs::Result<&mut C>`: A mutable reference to the [`DataConn`] instance if successful,
+    ///   or an [`errs::Err`] if the data source is not found, or if the retrieved/created
+    ///   [`DataConn`] cannot be cast to the specified type `C`.
     #[allow(async_fn_in_trait)]
     fn get_data_conn_async<C: DataConn + 'static>(
         &mut self,

--- a/src/txn_failure.rs
+++ b/src/txn_failure.rs
@@ -1,0 +1,356 @@
+// Copyright (C) 2026 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+use crate::{TxnFailureCause, TxnFailureRecovery, TxnFailureReport, TxnFailureRollback};
+
+use std::sync::Arc;
+
+impl TxnFailureReport {
+    pub(crate) fn new(name: Arc<str>, typ: &'static str) -> Self {
+        Self {
+            data_conn_name: name,
+            data_conn_type: typ,
+            cause: TxnFailureCause::NoneByUncommitted,
+            rollback: TxnFailureRollback::None,
+        }
+    }
+
+    /// Returns `true` if this connection was a cause of the transaction failure.
+    pub fn is_cause_of_failure(&self) -> bool {
+        !matches!(
+            self.cause,
+            TxnFailureCause::NoneByCommitted | TxnFailureCause::NoneByUncommitted
+        )
+    }
+
+    /// Determines the suggested recovery action for this connection to achieve a successful commit.
+    pub fn recovery_for_commit(&self) -> TxnFailureRecovery {
+        match (&self.cause, &self.rollback) {
+            (TxnFailureCause::NoneByCommitted, _) => TxnFailureRecovery::NoActionRequired,
+            (TxnFailureCause::PostCommitFailure(_), _) => TxnFailureRecovery::RetryPostCommit,
+            (_, TxnFailureRollback::Success) => TxnFailureRecovery::RerunAndCommit,
+            _ => TxnFailureRecovery::InvestigateAndRerunAndCommit,
+        }
+    }
+
+    /// Determines the suggested recovery action to achieve a rolled-back state for this connection.
+    pub fn recovery_for_rollback(&self) -> TxnFailureRecovery {
+        match self.rollback {
+            TxnFailureRollback::Success => TxnFailureRecovery::NoActionRequired,
+            TxnFailureRollback::None => match self.cause {
+                TxnFailureCause::NoneByCommitted => TxnFailureRecovery::CompensateRollback,
+                _ => TxnFailureRecovery::InvestigateAndRollback,
+            },
+            _ => TxnFailureRecovery::InvestigateAndRollback,
+        }
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn test_cause_is_none_by_committed_and_rollback_is_none() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::NoneByCommitted,
+            rollback: TxnFailureRollback::None,
+        };
+
+        assert!(!report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::NoActionRequired
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::CompensateRollback
+        );
+    }
+
+    // impossible case
+    #[test]
+    fn test_cause_is_none_by_committed_and_rollback_is_success() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::NoneByCommitted,
+            rollback: TxnFailureRollback::Success,
+        };
+
+        assert!(!report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::NoActionRequired
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::NoActionRequired
+        );
+    }
+
+    // impossible case
+    #[test]
+    fn test_cause_is_none_by_committed_and_rollback_is_failure() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::NoneByCommitted,
+            rollback: TxnFailureRollback::Failure(errs::Err::new("fail")),
+        };
+
+        assert!(!report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::NoActionRequired
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::InvestigateAndRollback
+        );
+    }
+
+    // impossible case
+    #[test]
+    fn test_cause_is_none_by_uncommitted_and_rollback_is_none() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::NoneByUncommitted,
+            rollback: TxnFailureRollback::None,
+        };
+
+        assert!(!report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::InvestigateAndRerunAndCommit
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::InvestigateAndRollback
+        );
+    }
+
+    #[test]
+    fn test_cause_is_none_by_uncommitted_and_rollback_is_success() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::NoneByUncommitted,
+            rollback: TxnFailureRollback::Success,
+        };
+
+        assert!(!report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::RerunAndCommit,
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::NoActionRequired,
+        );
+    }
+
+    #[test]
+    fn test_cause_is_none_by_uncommitted_and_rollback_is_failure() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::NoneByUncommitted,
+            rollback: TxnFailureRollback::Failure(errs::Err::new("fail")),
+        };
+
+        assert!(!report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::InvestigateAndRerunAndCommit
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::InvestigateAndRollback
+        );
+    }
+
+    #[test]
+    fn test_cause_is_run_failure_and_rollback_is_none() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::RunFailure(errs::Err::new("fail")),
+            rollback: TxnFailureRollback::None,
+        };
+
+        assert!(report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::InvestigateAndRerunAndCommit
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::InvestigateAndRollback
+        );
+    }
+
+    #[test]
+    fn test_cause_is_run_failure_and_rollback_is_success() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::RunFailure(errs::Err::new("fail")),
+            rollback: TxnFailureRollback::Success,
+        };
+
+        assert!(report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::RerunAndCommit,
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::NoActionRequired,
+        );
+    }
+
+    #[test]
+    fn test_cause_is_run_failure_and_rollback_is_failure() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::RunFailure(errs::Err::new("fail")),
+            rollback: TxnFailureRollback::Failure(errs::Err::new("fail")),
+        };
+
+        assert!(report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::InvestigateAndRerunAndCommit
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::InvestigateAndRollback
+        );
+    }
+
+    #[test]
+    fn test_cause_is_commit_failure_and_rollback_is_none() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::CommitFailure(errs::Err::new("fail")),
+            rollback: TxnFailureRollback::None,
+        };
+
+        assert!(report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::InvestigateAndRerunAndCommit
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::InvestigateAndRollback
+        );
+    }
+
+    #[test]
+    fn test_cause_is_commit_failure_and_rollback_is_success() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::CommitFailure(errs::Err::new("fail")),
+            rollback: TxnFailureRollback::Success,
+        };
+
+        assert!(report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::RerunAndCommit,
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::NoActionRequired,
+        );
+    }
+
+    #[test]
+    fn test_cause_is_commit_failure_and_rollback_is_failure() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::CommitFailure(errs::Err::new("fail")),
+            rollback: TxnFailureRollback::Failure(errs::Err::new("fail")),
+        };
+
+        assert!(report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::InvestigateAndRerunAndCommit
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::InvestigateAndRollback
+        );
+    }
+
+    #[test]
+    fn test_cause_is_post_commit_failure_and_rollback_is_none() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::PostCommitFailure(errs::Err::new("fail")),
+            rollback: TxnFailureRollback::None,
+        };
+
+        assert!(report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::RetryPostCommit,
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::InvestigateAndRollback
+        );
+    }
+
+    #[test]
+    fn test_cause_is_post_commit_failure_and_rollback_is_success() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::PostCommitFailure(errs::Err::new("fail")),
+            rollback: TxnFailureRollback::Success,
+        };
+
+        assert!(report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::RetryPostCommit,
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::NoActionRequired,
+        );
+    }
+
+    #[test]
+    fn test_cause_is_post_commit_failure_and_rollback_is_failure() {
+        let report = TxnFailureReport {
+            data_conn_name: "foo".into(),
+            data_conn_type: "A::B::C",
+            cause: TxnFailureCause::PostCommitFailure(errs::Err::new("fail")),
+            rollback: TxnFailureRollback::Failure(errs::Err::new("fail")),
+        };
+
+        assert!(report.is_cause_of_failure());
+        assert_eq!(
+            report.recovery_for_commit(),
+            TxnFailureRecovery::RetryPostCommit,
+        );
+        assert_eq!(
+            report.recovery_for_rollback(),
+            TxnFailureRecovery::InvestigateAndRollback,
+        );
+    }
+}

--- a/tests/run_async_tests.rs
+++ b/tests/run_async_tests.rs
@@ -30,6 +30,7 @@ mod run_async_tests {
         pub struct FooDataConn {
             text: Arc<String>,
             temp: String,
+            committed: bool,
         }
 
         impl FooDataConn {
@@ -37,6 +38,7 @@ mod run_async_tests {
                 Self {
                     text: text.clone(),
                     temp: text.to_string(),
+                    committed: true,
                 }
             }
 
@@ -53,10 +55,15 @@ mod run_async_tests {
             async fn commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 *Arc::get_mut(&mut self.text).unwrap() = self.temp.clone();
                 println!("commit text: {}", self.text.clone());
+                self.committed = true;
                 Ok(())
             }
-            async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {
+            fn is_committed(&self) -> bool {
+                self.committed
+            }
+            async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 self.temp = self.text.to_string();
+                Ok(())
             }
             fn close(&mut self) {}
         }
@@ -84,6 +91,7 @@ mod run_async_tests {
         pub struct BarDataConn {
             num: Arc<u32>,
             tmp: u32,
+            committed: bool,
         }
 
         impl BarDataConn {
@@ -91,6 +99,7 @@ mod run_async_tests {
                 Self {
                     num: num.clone(),
                     tmp: *num,
+                    committed: false,
                 }
             }
 
@@ -107,10 +116,15 @@ mod run_async_tests {
             async fn commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 *Arc::get_mut(&mut self.num).unwrap() = self.tmp.clone();
                 println!("commit num: {}", self.num.clone());
+                self.committed = true;
                 Ok(())
             }
-            async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {
+            fn is_committed(&self) -> bool {
+                self.committed
+            }
+            async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 self.tmp = *self.num;
+                Ok(())
             }
             fn close(&mut self) {}
         }

--- a/tests/run_tests.rs
+++ b/tests/run_tests.rs
@@ -29,6 +29,7 @@ mod run_tests {
         pub struct FooDataConn {
             text: Arc<String>,
             temp: String,
+            committed: bool,
         }
 
         impl FooDataConn {
@@ -36,6 +37,7 @@ mod run_tests {
                 Self {
                     text: text.clone(),
                     temp: text.to_string(),
+                    committed: false,
                 }
             }
 
@@ -52,10 +54,15 @@ mod run_tests {
             fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 *Arc::get_mut(&mut self.text).unwrap() = self.temp.clone();
                 println!("commit text: {}", self.text.clone());
+                self.committed = true;
                 Ok(())
             }
-            fn rollback(&mut self, _ag: &mut AsyncGroup) {
+            fn is_committed(&self) -> bool {
+                self.committed
+            }
+            fn rollback(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 self.temp = self.text.to_string();
+                Ok(())
             }
             fn close(&mut self) {}
         }
@@ -83,6 +90,7 @@ mod run_tests {
         pub struct BarDataConn {
             num: Arc<u32>,
             tmp: u32,
+            committed: bool,
         }
 
         impl BarDataConn {
@@ -90,6 +98,7 @@ mod run_tests {
                 Self {
                     num: num.clone(),
                     tmp: *num,
+                    committed: false,
                 }
             }
 
@@ -106,10 +115,15 @@ mod run_tests {
             fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 *Arc::get_mut(&mut self.num).unwrap() = self.tmp.clone();
                 println!("commit num: {}", self.num.clone());
+                self.committed = true;
                 Ok(())
             }
-            fn rollback(&mut self, _ag: &mut AsyncGroup) {
+            fn is_committed(&self) -> bool {
+                self.committed
+            }
+            fn rollback(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 self.tmp = *self.num;
+                Ok(())
             }
             fn close(&mut self) {}
         }

--- a/tests/txn_async_tests.rs
+++ b/tests/txn_async_tests.rs
@@ -30,6 +30,7 @@ mod txn_async_tests {
         pub struct FooDataConn {
             text: Arc<String>,
             temp: String,
+            committed: bool,
         }
 
         impl FooDataConn {
@@ -37,6 +38,7 @@ mod txn_async_tests {
                 Self {
                     text: text.clone(),
                     temp: text.to_string(),
+                    committed: false,
                 }
             }
 
@@ -53,10 +55,15 @@ mod txn_async_tests {
             async fn commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 *Arc::make_mut(&mut self.text) = self.temp.clone();
                 println!("commit text: {}", self.text.clone());
+                self.committed = true;
                 Ok(())
             }
-            async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {
+            fn is_committed(&self) -> bool {
+                self.committed
+            }
+            async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 self.temp = self.text.to_string();
+                Ok(())
             }
             fn close(&mut self) {}
         }
@@ -84,6 +91,7 @@ mod txn_async_tests {
         pub struct BarDataConn {
             num: Arc<u32>,
             tmp: u32,
+            committed: bool,
         }
 
         impl BarDataConn {
@@ -91,6 +99,7 @@ mod txn_async_tests {
                 Self {
                     num: num.clone(),
                     tmp: *num,
+                    committed: false,
                 }
             }
 
@@ -107,10 +116,15 @@ mod txn_async_tests {
             async fn commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 *Arc::make_mut(&mut self.num) = self.tmp.clone();
                 println!("commit num: {}", self.num.clone());
+                self.committed = true;
                 Ok(())
             }
-            async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {
+            fn is_committed(&self) -> bool {
+                self.committed
+            }
+            async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 self.tmp = *self.num;
+                Ok(())
             }
             fn close(&mut self) {}
         }

--- a/tests/txn_tests.rs
+++ b/tests/txn_tests.rs
@@ -29,6 +29,7 @@ mod txn_tests {
         pub struct FooDataConn {
             text: Arc<String>,
             temp: String,
+            committed: bool,
         }
 
         impl FooDataConn {
@@ -36,6 +37,7 @@ mod txn_tests {
                 Self {
                     text: text.clone(),
                     temp: text.to_string(),
+                    committed: false,
                 }
             }
 
@@ -52,10 +54,15 @@ mod txn_tests {
             fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 *Arc::make_mut(&mut self.text) = self.temp.clone();
                 println!("commit text: {}", self.text.clone());
+                self.committed = true;
                 Ok(())
             }
-            fn rollback(&mut self, _ag: &mut AsyncGroup) {
+            fn is_committed(&self) -> bool {
+                self.committed
+            }
+            fn rollback(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 self.temp = self.text.to_string();
+                Ok(())
             }
             fn close(&mut self) {}
         }
@@ -83,6 +90,7 @@ mod txn_tests {
         pub struct BarDataConn {
             num: Arc<u32>,
             tmp: u32,
+            committed: bool,
         }
 
         impl BarDataConn {
@@ -90,6 +98,7 @@ mod txn_tests {
                 Self {
                     num: num.clone(),
                     tmp: *num,
+                    committed: false,
                 }
             }
 
@@ -106,10 +115,15 @@ mod txn_tests {
             fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 *Arc::make_mut(&mut self.num) = self.tmp.clone();
                 println!("commit num: {}", self.num.clone());
+                self.committed = true;
                 Ok(())
             }
-            fn rollback(&mut self, _ag: &mut AsyncGroup) {
+            fn is_committed(&self) -> bool {
+                self.committed
+            }
+            fn rollback(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
                 self.tmp = *self.num;
+                Ok(())
             }
             fn close(&mut self) {}
         }

--- a/tests/uses_and_setup_async_in_static_tests.rs
+++ b/tests/uses_and_setup_async_in_static_tests.rs
@@ -6,17 +6,25 @@ mod uses_and_setup_async_in_static_tests {
 
     static LOGGER: LazyLock<Mutex<Vec<String>>> = LazyLock::new(|| Mutex::new(Vec::new()));
 
-    struct MyDataConn {}
+    struct MyDataConn {
+        committed: bool,
+    }
     impl MyDataConn {
         fn new() -> Self {
-            Self {}
+            Self { committed: false }
         }
     }
     impl DataConn for MyDataConn {
         async fn commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+            self.committed = true;
             Ok(())
         }
-        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {}
+        fn is_committed(&self) -> bool {
+            self.committed
+        }
+        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+            Ok(())
+        }
         fn close(&mut self) {}
     }
 

--- a/tests/uses_and_setup_in_func_tests.rs
+++ b/tests/uses_and_setup_in_func_tests.rs
@@ -2,17 +2,25 @@
 mod uses_and_setup_in_func_tests {
     use std::sync::{Arc, Mutex};
 
-    struct MyDataConn {}
+    struct MyDataConn {
+        committed: bool,
+    }
     impl MyDataConn {
         fn new() -> Self {
-            Self {}
+            Self { committed: false }
         }
     }
     impl sabi::DataConn for MyDataConn {
         fn commit(&mut self, _ag: &mut sabi::AsyncGroup) -> errs::Result<()> {
+            self.committed = true;
             Ok(())
         }
-        fn rollback(&mut self, _ag: &mut sabi::AsyncGroup) {}
+        fn is_committed(&self) -> bool {
+            self.committed
+        }
+        fn rollback(&mut self, _ag: &mut sabi::AsyncGroup) -> errs::Result<()> {
+            Ok(())
+        }
         fn close(&mut self) {}
     }
 

--- a/tests/uses_and_setup_in_static_tests.rs
+++ b/tests/uses_and_setup_in_static_tests.rs
@@ -4,17 +4,25 @@ mod uses_and_setup_in_static_tests {
 
     static LOGGER: LazyLock<Mutex<Vec<String>>> = LazyLock::new(|| Mutex::new(Vec::new()));
 
-    struct MyDataConn {}
+    struct MyDataConn {
+        committed: bool,
+    }
     impl MyDataConn {
         fn new() -> Self {
-            Self {}
+            Self { committed: false }
         }
     }
     impl sabi::DataConn for MyDataConn {
         fn commit(&mut self, _ag: &mut sabi::AsyncGroup) -> errs::Result<()> {
+            self.committed = true;
             Ok(())
         }
-        fn rollback(&mut self, _ag: &mut sabi::AsyncGroup) {}
+        fn is_committed(&self) -> bool {
+            self.committed
+        }
+        fn rollback(&mut self, _ag: &mut sabi::AsyncGroup) -> errs::Result<()> {
+            Ok(())
+        }
         fn close(&mut self) {}
     }
 

--- a/tests/uses_async_and_setup_async_in_func_tests.rs
+++ b/tests/uses_async_and_setup_async_in_func_tests.rs
@@ -4,17 +4,25 @@ mod uses_async_and_setup_async_in_func_tests {
     use sabi::tokio::{AsyncGroup, DataConn, DataSrc};
     use std::sync::{Arc, Mutex};
 
-    struct MyDataConn {}
+    struct MyDataConn {
+        committed: bool,
+    }
     impl MyDataConn {
         fn new() -> Self {
-            Self {}
+            Self { committed: false }
         }
     }
     impl DataConn for MyDataConn {
         async fn commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+            self.committed = true;
             Ok(())
         }
-        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {}
+        fn is_committed(&self) -> bool {
+            self.committed
+        }
+        async fn rollback_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+            Ok(())
+        }
         fn close(&mut self) {}
     }
 


### PR DESCRIPTION
Resolves #103 

### Overview
This PR changes the error handling and transaction failure lifecycle within `DataConn` by removing the deprecated `force_back` mechanism and introducing a more comprehensive `on_txn_failure` callback.

### Key Changes
* **Removed:** `should_force_back` and `force_back` / `force_back_async` methods from the `DataConn` trait.
* **Added:** `is_committed` method to track connection status.
* **Added:** `on_txn_failure` / `on_txn_failure` lifecycle callbacks that accept a slice/Arc of `TxnFailureReport`, allowing connections to handle post-failure tasks or custom recovery logic with full transaction context.
* **Updated:** Refactored `DataHub::txn` and `DataHub::txn_async` to generate failure reports and pass them down during rollbacks.
* **New Structs/Enums:** Introduced `TxnFailureReport`, `TxnFailureCause`, `TxnFailureRollback`, and `TxnFailureRecovery` to formally represent transaction failure states and recommended recovery actions.