### PR TITLE
fix: changed setup_with_order to close in reverse order upon error

### DIFF
--- a/src/data_src/mod.rs
+++ b/src/data_src/mod.rs
@@ -240,18 +240,17 @@ impl DataSrcManager {
                 self.vec_ready.push(ssnnptr);
             }
         } else {
+            for ssnnptr in self.vec_unready[0..n_done].iter().rev().flatten() {
+                let ptr = ssnnptr.non_null_ptr.as_ptr();
+                let close_fn = unsafe { (*ptr).close_fn };
+                close_fn(ptr);
+            }
             for (i, err) in indexed_errors.into_iter() {
                 if let Some(ssnnptr) = &self.vec_unready[i] {
                     let ptr = ssnnptr.non_null_ptr.as_ptr();
                     let name = unsafe { (*ptr).name.clone() };
                     errors.push((name, err));
                 }
-            }
-
-            for ssnnptr in self.vec_unready[0..n_done].iter().rev().flatten() {
-                let ptr = ssnnptr.non_null_ptr.as_ptr();
-                let close_fn = unsafe { (*ptr).close_fn };
-                close_fn(ptr);
             }
         }
     }
@@ -314,7 +313,7 @@ impl DataSrcManager {
                 }
             }
         } else {
-            for vec_index in ordered_indexes.iter().take(n_done).flatten() {
+            for vec_index in ordered_indexes.iter().take(n_done).flatten().rev() {
                 if let Some(ssnnptr) = &self.vec_unready[*vec_index] {
                     let ptr = ssnnptr.non_null_ptr.as_ptr();
                     let close_fn = unsafe { (*ptr).close_fn };
@@ -956,9 +955,9 @@ mod tests_of_data_src {
             assert_eq!(errors.len(), 1);
             assert_eq!(errors[0].0, "bar".into());
             #[cfg(unix)]
-            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src/data_src/mod.rs, line = 475 }");
+            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src/data_src/mod.rs, line = 474 }");
             #[cfg(windows)]
-            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src\\data_src\\mod.rs, line = 475 }");
+            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src\\data_src\\mod.rs, line = 474 }");
         }
 
         assert_eq!(
@@ -1042,23 +1041,26 @@ mod tests_of_data_src {
             let ds3 = SyncDataSrc::new(3, logger.clone(), false);
             manager.add("baz", ds3);
 
+            let ds4 = SyncDataSrc::new(4, logger.clone(), false);
+            manager.add("qux", ds4);
+
             assert!(manager.local);
-            assert_eq!(manager.vec_unready.len(), 3);
+            assert_eq!(manager.vec_unready.len(), 4);
             assert_eq!(manager.vec_ready.len(), 0);
 
             let mut errors = Vec::new();
-            manager.setup_with_order(&["baz", "foo"], &mut errors);
+            manager.setup_with_order(&["qux", "baz", "foo"], &mut errors);
 
             assert!(manager.local);
-            assert_eq!(manager.vec_unready.len(), 3);
+            assert_eq!(manager.vec_unready.len(), 4);
             assert_eq!(manager.vec_ready.len(), 0);
 
             assert_eq!(errors.len(), 1);
             assert_eq!(errors[0].0, "foo".into());
             #[cfg(unix)]
-            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src/data_src/mod.rs, line = 475 }");
+            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src/data_src/mod.rs, line = 474 }");
             #[cfg(windows)]
-            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src\\data_src\\mod.rs, line = 475 }");
+            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src\\data_src\\mod.rs, line = 474 }");
         }
 
         assert_eq!(
@@ -1067,9 +1069,13 @@ mod tests_of_data_src {
                 "SyncDataSrc::new 1",
                 "SyncDataSrc::new 2",
                 "SyncDataSrc::new 3",
+                "SyncDataSrc::new 4",
+                "SyncDataSrc::setup 4",
                 "SyncDataSrc::setup 3",
                 "SyncDataSrc::setup 1 failed",
                 "SyncDataSrc::close 3",
+                "SyncDataSrc::close 4",
+                "SyncDataSrc::drop 4",
                 "SyncDataSrc::drop 3",
                 "SyncDataSrc::drop 2",
                 "SyncDataSrc::drop 1",

--- a/src/tokio/data_src/mod.rs
+++ b/src/tokio/data_src/mod.rs
@@ -253,18 +253,17 @@ impl DataSrcManager {
                 self.vec_ready.push(ssnnptr);
             }
         } else {
+            for ssnnptr in self.vec_unready[0..n_done].iter().rev().flatten() {
+                let ptr = ssnnptr.non_null_ptr.as_ptr();
+                let close_fn = unsafe { (*ptr).close_fn };
+                close_fn(ptr);
+            }
             for (i, err) in indexed_errors.into_iter() {
                 if let Some(ssnnptr) = &self.vec_unready[i] {
                     let ptr = ssnnptr.non_null_ptr.as_ptr();
                     let name = unsafe { (*ptr).name.clone() };
                     errors.push((name, err));
                 }
-            }
-
-            for ssnnptr in self.vec_unready[0..n_done].iter().rev().flatten() {
-                let ptr = ssnnptr.non_null_ptr.as_ptr();
-                let close_fn = unsafe { (*ptr).close_fn };
-                close_fn(ptr);
             }
         }
     }
@@ -1068,25 +1067,28 @@ mod tests_of_data_src {
             let ds3 = SyncDataSrc::new(3, logger.clone(), false);
             manager.add("baz", ds3);
 
+            let ds4 = SyncDataSrc::new(4, logger.clone(), false);
+            manager.add("qux", ds4);
+
             assert!(manager.local);
-            assert_eq!(manager.vec_unready.len(), 3);
+            assert_eq!(manager.vec_unready.len(), 4);
             assert_eq!(manager.vec_ready.len(), 0);
 
             let mut errors = Vec::new();
             manager
-                .setup_with_order_async(&["baz", "foo"], &mut errors)
+                .setup_with_order_async(&["qux", "baz", "foo"], &mut errors)
                 .await;
 
             assert!(manager.local);
-            assert_eq!(manager.vec_unready.len(), 3);
+            assert_eq!(manager.vec_unready.len(), 4);
             assert_eq!(manager.vec_ready.len(), 0);
 
             assert_eq!(errors.len(), 1);
             assert_eq!(errors[0].0, "foo".into());
             #[cfg(unix)]
-            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src/tokio/data_src/mod.rs, line = 500 }");
+            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src/tokio/data_src/mod.rs, line = 499 }");
             #[cfg(windows)]
-            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src\\tokio\\data_src\\mod.rs, line = 500 }");
+            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src\\tokio\\data_src\\mod.rs, line = 499 }");
         }
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -1095,12 +1097,16 @@ mod tests_of_data_src {
         assert!(locked.contains(&"SyncDataSrc::new 1".to_string()));
         assert!(locked.contains(&"SyncDataSrc::new 2".to_string()));
         assert!(locked.contains(&"SyncDataSrc::new 3".to_string()));
+        assert!(locked.contains(&"SyncDataSrc::new 4".to_string()));
+        assert!(locked.contains(&"SyncDataSrc::setup 4".to_string()));
         assert!(locked.contains(&"SyncDataSrc::setup 3".to_string()));
         assert!(locked.contains(&"SyncDataSrc::setup 1 failed".to_string()));
+        assert!(locked.contains(&"SyncDataSrc::close 4".to_string()));
         assert!(locked.contains(&"SyncDataSrc::close 3".to_string()));
         assert!(locked.contains(&"SyncDataSrc::drop 2".to_string()));
         assert!(locked.contains(&"SyncDataSrc::drop 1".to_string()));
         assert!(locked.contains(&"SyncDataSrc::drop 3".to_string()));
+        assert!(locked.contains(&"SyncDataSrc::drop 4".to_string()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
In other parts of the codebase, close operations are executed in the reverse order of setup. Since the logic to reverse the order was missing in `setup_with_order` and `setup_with_order_async`, I am adding it.