### PR TITLE
refactor: manually implemented Copy trait for SendSyncNonNull<T>

### DIFF
--- a/src/data_conn.rs
+++ b/src/data_conn.rs
@@ -204,7 +204,7 @@ impl DataConnManager {
                     let ptr = ssnnptr.non_null_ptr.as_ptr();
                     let cont_name = unsafe { &(*ptr).name };
                     if cont_name.as_ref() == name.as_ref() {
-                        return Some(ssnnptr.clone());
+                        return Some(*ssnnptr);
                     }
                 }
             }

--- a/src/non_null.rs
+++ b/src/non_null.rs
@@ -18,9 +18,15 @@ impl<T: Send + Sync> SendSyncNonNull<T> {
 unsafe impl<T: Send + Sync> Send for SendSyncNonNull<T> {}
 unsafe impl<T: Send + Sync> Sync for SendSyncNonNull<T> {}
 
+// Clone and Copy are implemented manually to avoid introducing
+// unnecessary trait bounds such as `T: Clone` or `T: Copy`.
+// This type is merely a wrapper around a non-owning pointer, so
+// cloning or copying it only duplicates the pointer value.
+impl<T: Send + Sync> Copy for SendSyncNonNull<T> {}
+
 impl<T: Send + Sync> Clone for SendSyncNonNull<T> {
     #[inline(always)]
     fn clone(&self) -> Self {
-        SendSyncNonNull::new(self.non_null_ptr)
+        *self
     }
 }

--- a/src/tokio/data_conn.rs
+++ b/src/tokio/data_conn.rs
@@ -206,7 +206,7 @@ impl DataConnManager {
                     let ptr = ssnnptr.non_null_ptr.as_ptr();
                     let cont_name = unsafe { &(*ptr).name };
                     if cont_name.as_ref() == name.as_ref() {
-                        return Some(ssnnptr.clone());
+                        return Some(*ssnnptr);
                     }
                 }
             }


### PR DESCRIPTION
Since `SendSyncNonNull<T>` is a non-owning pointer wrapper, its copyability depends only on the contained pointer value and not on `T`. A manual implementation avoids unnecessary trait bounds that may be introduced by automatic derivation and makes the intended semantics explicit.

### Checklist for `SendSyncNonNull<T>`

Before implementing `Copy` for `SendSyncNonNull<T>`, the following conditions should be verified:

* [x] `SendSyncNonNull<T>` is a non-owning pointer wrapper.
* [x] Copying the value only duplicates the pointer value.
* [x] The type does not own or manage the lifetime of the pointee.
* [x] The type does not implement `Drop`.
* [x] Copyability is independent of the properties of `T`.
* [x] Copying the value does not violate any invariants of the type.
* [x] The existing safety assumptions for `Send` and `Sync` remain unchanged after copying.
* [x] Implicit copying is consistent with the intended semantics of the type.

Since all of these conditions are satisfied, a manual implementation of `Copy` for `SendSyncNonNull<T>` is considered safe and appropriate.
