### PR TITLE
fix: made DataConn not roll back when post-commits fail

### DIFF
--- a/src/data_conn.rs
+++ b/src/data_conn.rs
@@ -164,6 +164,7 @@ impl DataConnManager {
         Self {
             vec: Vec::new(),
             index_map: HashMap::new(),
+            committed: false,
         }
     }
 
@@ -177,6 +178,7 @@ impl DataConnManager {
         Self {
             vec: vec![None; names.len()],
             index_map,
+            committed: false,
         }
     }
 
@@ -247,7 +249,7 @@ impl DataConnManager {
         reports
     }
 
-    pub(crate) fn commit(&self, reports: &mut [TxnFailureReport]) -> errs::Result<()> {
+    pub(crate) fn commit(&mut self, reports: &mut [TxnFailureReport]) -> errs::Result<()> {
         let mut indexed_errors = Vec::new();
 
         let mut ag = AsyncGroup::new();
@@ -304,6 +306,8 @@ impl DataConnManager {
             }));
         }
 
+        self.committed = true;
+
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
@@ -343,6 +347,9 @@ impl DataConnManager {
                 if let TxnFailureCause::NoneByUncommitted = report.cause {
                     report.cause = TxnFailureCause::NoneByCommitted;
                 }
+                continue;
+            }
+            if self.committed {
                 continue;
             }
             let rollback_fn = unsafe { (*ptr).rollback_fn };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,7 @@ where
 struct DataConnManager {
     vec: Vec<Option<SendSyncNonNull<DataConnContainer>>>,
     index_map: HashMap<Arc<str>, usize>,
+    committed: bool,
 }
 
 /// The trait that abstracts a data source responsible for managing connections

--- a/src/tokio/data_conn.rs
+++ b/src/tokio/data_conn.rs
@@ -166,6 +166,7 @@ impl DataConnManager {
         Self {
             vec: Vec::new(),
             index_map: HashMap::new(),
+            committed: false,
         }
     }
 
@@ -179,6 +180,7 @@ impl DataConnManager {
         Self {
             vec: vec![None; names.len()],
             index_map,
+            committed: false,
         }
     }
 
@@ -249,7 +251,10 @@ impl DataConnManager {
         reports
     }
 
-    pub(crate) async fn commit_async(&self, reports: &mut [TxnFailureReport]) -> errs::Result<()> {
+    pub(crate) async fn commit_async(
+        &mut self,
+        reports: &mut [TxnFailureReport],
+    ) -> errs::Result<()> {
         let mut indexed_errors = Vec::new();
 
         let mut ag = AsyncGroup::new();
@@ -306,6 +311,8 @@ impl DataConnManager {
             }));
         }
 
+        self.committed = true;
+
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
@@ -345,6 +352,9 @@ impl DataConnManager {
                 if let TxnFailureCause::NoneByUncommitted = report.cause {
                     report.cause = TxnFailureCause::NoneByCommitted;
                 }
+                continue;
+            }
+            if self.committed {
                 continue;
             }
             let rollback_fn = unsafe { (*ptr).rollback_fn };

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -250,6 +250,7 @@ where
 pub(crate) struct DataConnManager {
     vec: Vec<Option<SendSyncNonNull<DataConnContainer>>>,
     index_map: HashMap<Arc<str>, usize>,
+    committed: bool,
 }
 
 /// The trait that abstracts a data source responsible for managing connections


### PR DESCRIPTION
This PR changes the behavior so that `DataConn` (data connection) is not rolled back when post-commit processes fail. 
This is because all commit operations themselves have already succeeded by the time the post-commit processes run, meaning a rollback must not be executed after that point.