### PR TITLE
update!: introduced ErrEntry for error reasons which store multiple Errs

### DIFF
--- a/src/async_group.rs
+++ b/src/async_group.rs
@@ -2,7 +2,7 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-use crate::AsyncGroup;
+use crate::{AsyncGroup, ErrEntry};
 
 use std::{mem, thread};
 
@@ -19,6 +19,7 @@ impl AsyncGroup {
         Self {
             handlers: Vec::new(),
             _index: 0,
+            _name: Default::default(),
         }
     }
 
@@ -39,10 +40,11 @@ impl AsyncGroup {
     where
         F: FnOnce() -> errs::Result<()> + Send + 'static,
     {
-        self.handlers.push((self._index, thread::spawn(f)));
+        self.handlers
+            .push((self._index, self._name.clone(), thread::spawn(f)));
     }
 
-    pub(crate) fn join_and_collect_errors(mut self, errors: &mut Vec<(usize, errs::Err)>) {
+    pub(crate) fn join_and_collect_errors(mut self, errors: &mut Vec<ErrEntry>) {
         if self.handlers.is_empty() {
             return;
         }
@@ -50,10 +52,14 @@ impl AsyncGroup {
         let vec = mem::take(&mut self.handlers);
 
         for h in vec.into_iter() {
-            match h.1.join() {
+            match h.2.join() {
                 Ok(r) => {
                     if let Err(e) = r {
-                        errors.push((h.0, e));
+                        errors.push(ErrEntry {
+                            index: h.0,
+                            name: h.1,
+                            err: e,
+                        });
                     }
                 }
                 Err(e) => {
@@ -65,7 +71,11 @@ impl AsyncGroup {
                         "Unknown panic payload".to_string()
                     };
                     let e = errs::Err::new(AsyncGroupError::ThreadPanicked(s));
-                    errors.push((h.0, e));
+                    errors.push(ErrEntry {
+                        index: h.0,
+                        name: h.1,
+                        err: e,
+                    });
                 }
             }
         }
@@ -79,7 +89,7 @@ impl AsyncGroup {
         let vec = mem::take(&mut self.handlers);
 
         for h in vec.into_iter() {
-            let _ = h.1.join();
+            let _ = h.2.join();
         }
     }
 }
@@ -194,6 +204,7 @@ mod tests_of_async_group {
             assert_eq!(*struct_a.string.lock().unwrap(), "a");
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             let mut errors = Vec::new();
@@ -202,15 +213,16 @@ mod tests_of_async_group {
             assert_eq!(errors.len(), 1);
             assert_eq!(*struct_a.string.lock().unwrap(), "a");
 
-            assert_eq!(errors[0].0, 12);
+            assert_eq!(errors[0].index, 12);
+            assert_eq!(errors[0].name, "foo".into());
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", errors[0].1),
+                format!("{:?}", errors[0].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"a\"), file = src/async_group.rs, line = ".to_string() + &(BASE_LINE + 28).to_string() + " }"
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", errors[0].1),
+                format!("{:?}", errors[0].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"a\"), file = src\\async_group.rs, line = ".to_string() + &(BASE_LINE + 28).to_string() + " }"
             );
         }
@@ -229,12 +241,15 @@ mod tests_of_async_group {
             assert_eq!(*struct_c.string.lock().unwrap(), "c".to_string());
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag._index = 34;
+            ag._name = "bar".into();
             struct_b.process(&mut ag);
 
             ag._index = 56;
+            ag._name = "baz".into();
             struct_c.process(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -261,27 +276,31 @@ mod tests_of_async_group {
             assert_eq!(*struct_c.string.lock().unwrap(), "c");
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag._index = 34;
+            ag._name = "bar".into();
             struct_b.process(&mut ag);
 
             ag._index = 56;
+            ag._name = "baz".into();
             struct_c.process(&mut ag);
 
             let mut err_vec = Vec::new();
             ag.join_and_collect_errors(&mut err_vec);
 
             assert_eq!(err_vec.len(), 1);
-            assert_eq!(err_vec[0].0, 34);
+            assert_eq!(err_vec[0].index, 34);
+            assert_eq!(err_vec[0].name, "bar".into());
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", err_vec[0].1),
+                format!("{:?}", err_vec[0].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"b\"), file = src/async_group.rs, line = ".to_string() + &(BASE_LINE + 28).to_string() + " }",
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", err_vec[0].1),
+                format!("{:?}", err_vec[0].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"b\"), file = src\\async_group.rs, line = ".to_string() + &(BASE_LINE + 28).to_string() + " }",
             );
 
@@ -304,12 +323,15 @@ mod tests_of_async_group {
             assert_eq!(*struct_c.string.lock().unwrap(), "c");
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag._index = 34;
+            ag._name = "bar".into();
             struct_b.process(&mut ag);
 
             ag._index = 56;
+            ag._name = "baz".into();
             struct_c.process(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -317,38 +339,42 @@ mod tests_of_async_group {
 
             assert_eq!(err_vec.len(), 3);
 
-            assert_eq!(err_vec[0].0, 12);
-            assert_eq!(err_vec[1].0, 34);
-            assert_eq!(err_vec[2].0, 56);
+            assert_eq!(err_vec[0].index, 12);
+            assert_eq!(err_vec[1].index, 34);
+            assert_eq!(err_vec[2].index, 56);
+
+            assert_eq!(err_vec[0].name, "foo".into());
+            assert_eq!(err_vec[1].name, "bar".into());
+            assert_eq!(err_vec[2].name, "baz".into());
 
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", err_vec[0].1),
+                format!("{:?}", err_vec[0].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"a\"), file = src/async_group.rs, line = ".to_string() + &(BASE_LINE + 28).to_string() + " }",
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", err_vec[0].1),
+                format!("{:?}", err_vec[0].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"a\"), file = src\\async_group.rs, line = ".to_string() + &(BASE_LINE + 28).to_string() + " }",
             );
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", err_vec[1].1),
+                format!("{:?}", err_vec[1].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"b\"), file = src/async_group.rs, line = ".to_string() + &(BASE_LINE + 28).to_string() + " }",
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", err_vec[1].1),
+                format!("{:?}", err_vec[1].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"b\"), file = src\\async_group.rs, line = ".to_string() + &(BASE_LINE + 28).to_string() + " }",
             );
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", err_vec[2].1),
+                format!("{:?}", err_vec[2].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"c\"), file = src/async_group.rs, line = ".to_string() + &(BASE_LINE + 28).to_string() + " }",
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", err_vec[2].1),
+                format!("{:?}", err_vec[2].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"c\"), file = src\\async_group.rs, line = ".to_string() + &(BASE_LINE + 28).to_string() + " }",
             );
 
@@ -365,6 +391,7 @@ mod tests_of_async_group {
             assert_eq!(*struct_d.string.lock().unwrap(), "d");
 
             ag._index = 123;
+            ag._name = "foo".into();
             struct_d.process(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -383,6 +410,7 @@ mod tests_of_async_group {
             assert_eq!(*struct_d.string.lock().unwrap(), "d");
 
             ag._index = 123;
+            ag._name = "foo".into();
             struct_d.process_multiple(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -390,28 +418,31 @@ mod tests_of_async_group {
 
             assert_eq!(err_vec.len(), 2);
 
-            assert_eq!(err_vec[0].0, 123);
-            assert_eq!(err_vec[1].0, 123);
+            assert_eq!(err_vec[0].index, 123);
+            assert_eq!(err_vec[1].index, 123);
+
+            assert_eq!(err_vec[0].name, "foo".into());
+            assert_eq!(err_vec[1].name, "foo".into());
 
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", err_vec[0].1),
+                format!("{:?}", err_vec[0].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"d\"), file = src/async_group.rs, line = ".to_string() + &(BASE_LINE + 44).to_string() + " }",
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", err_vec[0].1),
+                format!("{:?}", err_vec[0].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"d\"), file = src\\async_group.rs, line = ".to_string() + &(BASE_LINE + 44).to_string() + " }"
             );
 
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", err_vec[1].1),
+                format!("{:?}", err_vec[1].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"d\"), file = src/async_group.rs, line = ".to_string() + &(BASE_LINE + 58).to_string() + " }",
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", err_vec[1].1),
+                format!("{:?}", err_vec[1].err),
                 "errs::Err { reason = sabi::async_group::tests_of_async_group::Reasons BadString(\"d\"), file = src\\async_group.rs, line = ".to_string() + &(BASE_LINE + 58).to_string() + " }"
             );
 
@@ -437,6 +468,7 @@ mod tests_of_async_group {
             assert_eq!(*struct_a.string.lock().unwrap(), "a");
 
             ag._index = 123;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag.join_and_ignore_errors();
@@ -451,6 +483,7 @@ mod tests_of_async_group {
             assert_eq!(*struct_a.string.lock().unwrap(), "a");
 
             ag._index = 123;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag.join_and_ignore_errors();
@@ -471,12 +504,15 @@ mod tests_of_async_group {
             assert_eq!(*struct_c.string.lock().unwrap(), "c");
 
             ag._index = 123;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag._index = 456;
+            ag._name = "bar".into();
             struct_b.process(&mut ag);
 
             ag._index = 789;
+            ag._name = "baz".into();
             struct_c.process(&mut ag);
 
             ag.join_and_ignore_errors();
@@ -500,12 +536,15 @@ mod tests_of_async_group {
             assert_eq!(*struct_c.string.lock().unwrap(), "c");
 
             ag._index = 123;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag._index = 456;
+            ag._name = "bar".into();
             struct_b.process(&mut ag);
 
             ag._index = 789;
+            ag._name = "baz".into();
             struct_c.process(&mut ag);
 
             ag.join_and_ignore_errors();
@@ -529,12 +568,15 @@ mod tests_of_async_group {
             assert_eq!(*struct_c.string.lock().unwrap(), "c");
 
             ag._index = 123;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag._index = 456;
+            ag._name = "foo".into();
             struct_b.process(&mut ag);
 
             ag._index = 789;
+            ag._name = "foo".into();
             struct_c.process(&mut ag);
 
             ag.join_and_ignore_errors();

--- a/src/data_conn.rs
+++ b/src/data_conn.rs
@@ -3,8 +3,8 @@
 // See the file LICENSE in this distribution for more details.
 
 use crate::{
-    AsyncGroup, DataConn, DataConnContainer, DataConnManager, SendSyncNonNull, TxnFailureCause,
-    TxnFailureReport, TxnFailureRollback,
+    AsyncGroup, DataConn, DataConnContainer, DataConnManager, ErrEntry, SendSyncNonNull,
+    TxnFailureCause, TxnFailureReport, TxnFailureRollback,
 };
 
 use std::collections::HashMap;
@@ -20,7 +20,7 @@ pub enum DataConnError {
     /// Contains a vector of data connection names and their corresponding errors.
     FailToPreCommitDataConn {
         /// The vector contains errors that occurred in each [`DataConn`] object.
-        errors: Vec<(Arc<str>, errs::Err)>,
+        errors: Vec<ErrEntry>,
     },
 
     /// Indicates a failure during the commit process of one or more [`DataConn`] instances
@@ -28,7 +28,7 @@ pub enum DataConnError {
     /// Contains a vector of data connection names and their corresponding errors.
     FailToCommitDataConn {
         /// The vector contains errors that occurred in each [`DataConn`] object.
-        errors: Vec<(Arc<str>, errs::Err)>,
+        errors: Vec<ErrEntry>,
     },
 
     /// Indicates a failure during the post-commit process of one or more [`DataConn`] instances
@@ -36,7 +36,7 @@ pub enum DataConnError {
     /// Contains a vector of data connection names and their corresponding errors.
     FailToPostCommitDataConn {
         /// The vector contains errors that occurred in each [`DataConn`] object.
-        errors: Vec<(Arc<str>, errs::Err)>,
+        errors: Vec<ErrEntry>,
     },
 
     /// Indicates a failure to cast a retrieved [`DataConn`] to the expected type.
@@ -250,26 +250,30 @@ impl DataConnManager {
     }
 
     pub(crate) fn commit(&mut self, reports: &mut [TxnFailureReport]) -> errs::Result<()> {
-        let mut indexed_errors = Vec::new();
+        let mut errors = Vec::new();
 
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let pre_commit_fn = unsafe { (*ptr).pre_commit_fn };
+            let name = unsafe { &(*ptr).name };
             ag._index = i;
+            ag._name = name.clone();
             if let Err(err) = pre_commit_fn(ptr, &mut ag) {
-                indexed_errors.push((ag._index, err));
+                errors.push(ErrEntry {
+                    index: i,
+                    name: name.clone(),
+                    err,
+                });
                 break;
             }
         }
-        ag.join_and_collect_errors(&mut indexed_errors);
+        ag.join_and_collect_errors(&mut errors);
 
-        if !indexed_errors.is_empty() {
-            let mut errors = Vec::new();
-            for (i, err) in indexed_errors.into_iter() {
-                let report = &mut reports[i];
-                report.cause = TxnFailureCause::LogicFailure(err.clone());
-                errors.push((report.data_conn_name.clone(), err));
+        if !errors.is_empty() {
+            for ee in errors.iter() {
+                let report = &mut reports[ee.index];
+                report.cause = TxnFailureCause::LogicFailure(ee.err.clone());
             }
             return Err(errs::Err::new(DataConnError::FailToPreCommitDataConn {
                 errors,
@@ -286,20 +290,24 @@ impl DataConnManager {
                 continue;
             }
             let commit_fn = unsafe { (*ptr).commit_fn };
+            let name = unsafe { &(*ptr).name };
             ag._index = i;
+            ag._name = name.clone();
             if let Err(err) = commit_fn(ptr, &mut ag) {
-                indexed_errors.push((ag._index, err));
+                errors.push(ErrEntry {
+                    index: i,
+                    name: name.clone(),
+                    err,
+                });
                 break;
             }
         }
-        ag.join_and_collect_errors(&mut indexed_errors);
+        ag.join_and_collect_errors(&mut errors);
 
-        if !indexed_errors.is_empty() {
-            let mut errors = Vec::new();
-            for (i, err) in indexed_errors.into_iter() {
-                let report = &mut reports[i];
-                report.cause = TxnFailureCause::CommitFailure(err.clone());
-                errors.push((report.data_conn_name.clone(), err));
+        if !errors.is_empty() {
+            for ee in errors.iter() {
+                let report = &mut reports[ee.index];
+                report.cause = TxnFailureCause::CommitFailure(ee.err.clone());
             }
             return Err(errs::Err::new(DataConnError::FailToCommitDataConn {
                 errors,
@@ -312,20 +320,24 @@ impl DataConnManager {
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let post_commit_fn = unsafe { (*ptr).post_commit_fn };
+            let name = unsafe { &(*ptr).name };
             ag._index = i;
+            ag._name = name.clone();
             if let Err(err) = post_commit_fn(ptr, &mut ag) {
-                indexed_errors.push((ag._index, err));
+                errors.push(ErrEntry {
+                    index: i,
+                    name: name.clone(),
+                    err,
+                });
                 // don't break;
             }
         }
-        ag.join_and_collect_errors(&mut indexed_errors);
+        ag.join_and_collect_errors(&mut errors);
 
-        if !indexed_errors.is_empty() {
-            let mut errors = Vec::new();
-            for (i, err) in indexed_errors.into_iter() {
-                let report = &mut reports[i];
-                report.cause = TxnFailureCause::PostCommitFailure(err.clone());
-                errors.push((report.data_conn_name.clone(), err));
+        if !errors.is_empty() {
+            for ee in errors.iter() {
+                let report = &mut reports[ee.index];
+                report.cause = TxnFailureCause::PostCommitFailure(ee.err.clone());
             }
             return Err(errs::Err::new(DataConnError::FailToPostCommitDataConn {
                 errors,
@@ -336,7 +348,7 @@ impl DataConnManager {
     }
 
     pub(crate) fn rollback(&mut self, mut reports: Vec<TxnFailureReport>) {
-        let mut indexed_errors = Vec::new();
+        let mut errors = Vec::new();
 
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
@@ -353,19 +365,25 @@ impl DataConnManager {
                 continue;
             }
             let rollback_fn = unsafe { (*ptr).rollback_fn };
+            let name = unsafe { &(*ptr).name };
             ag._index = i;
+            ag._name = name.clone();
             if let Err(err) = rollback_fn(ptr, &mut ag) {
-                indexed_errors.push((ag._index, err));
+                errors.push(ErrEntry {
+                    index: i,
+                    name: name.clone(),
+                    err,
+                });
             } else {
                 report.rollback = TxnFailureRollback::NoneByRolledBack;
             }
         }
-        ag.join_and_collect_errors(&mut indexed_errors);
+        ag.join_and_collect_errors(&mut errors);
 
-        if !indexed_errors.is_empty() {
-            for (i, err) in indexed_errors.into_iter() {
-                let report = &mut reports[i];
-                report.rollback = TxnFailureRollback::RollbackFailure(err);
+        if !errors.is_empty() {
+            for ee in errors.into_iter() {
+                let report = &mut reports[ee.index];
+                report.rollback = TxnFailureRollback::RollbackFailure(ee.err);
             }
         }
 
@@ -1121,8 +1139,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "zzz");
+                            assert_eq!(errors[0].index, 0);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "zzz");
                         }
                         _ => panic!(),
                     }
@@ -1198,10 +1217,12 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 2);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "zzz");
-                            assert_eq!(errors[1].0, "bar".into());
-                            assert_eq!(errors[1].1.reason::<String>().unwrap(), "yyy");
+                            assert_eq!(errors[0].index, 1);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "zzz");
+                            assert_eq!(errors[1].index, 0);
+                            assert_eq!(errors[1].name, "bar".into());
+                            assert_eq!(errors[1].err.reason::<String>().unwrap(), "yyy");
                         }
                         _ => panic!(),
                     }
@@ -1279,8 +1300,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "bar".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "yyy");
+                            assert_eq!(errors[0].index, 1);
+                            assert_eq!(errors[0].name, "bar".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "yyy");
                         }
                         _ => panic!(),
                     }
@@ -1358,8 +1380,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "ZZZ");
+                            assert_eq!(errors[0].index, 0);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "ZZZ");
                         }
                         _ => panic!(),
                     }
@@ -1439,8 +1462,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "YYY");
+                            assert_eq!(errors[0].index, 0);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "YYY");
                         }
                         _ => panic!(),
                     }
@@ -1520,8 +1544,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "bar".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "YYY");
+                            assert_eq!(errors[0].index, 1);
+                            assert_eq!(errors[0].name, "bar".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "YYY");
                         }
                         _ => panic!(),
                     }
@@ -1601,10 +1626,12 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 2);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "!!!");
-                            assert_eq!(errors[1].0, "bar".into());
-                            assert_eq!(errors[1].1.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[0].index, 0);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[1].index, 1);
+                            assert_eq!(errors[1].name, "bar".into());
+                            assert_eq!(errors[1].err.reason::<String>().unwrap(), "!!!");
                         }
                         _ => panic!(),
                     }
@@ -1686,10 +1713,12 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 2);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "!!!");
-                            assert_eq!(errors[1].0, "bar".into());
-                            assert_eq!(errors[1].1.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[0].index, 1);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[1].index, 0);
+                            assert_eq!(errors[1].name, "bar".into());
+                            assert_eq!(errors[1].err.reason::<String>().unwrap(), "!!!");
                         }
                         _ => panic!(),
                     }
@@ -1771,8 +1800,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "bar".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[0].index, 1);
+                            assert_eq!(errors[0].name, "bar".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "!!!");
                         }
                         _ => panic!(),
                     }
@@ -2047,8 +2077,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "ZZZ");
+                            assert_eq!(errors[0].index, 0);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "ZZZ");
                         }
                         _ => panic!(),
                     }
@@ -2120,8 +2151,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "bar".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "YYY");
+                            assert_eq!(errors[0].index, 1);
+                            assert_eq!(errors[0].name, "bar".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "YYY");
                         }
                         _ => panic!(),
                     }
@@ -2235,8 +2267,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "bar".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "YYY");
+                            assert_eq!(errors[0].index, 1);
+                            assert_eq!(errors[0].name, "bar".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "YYY");
                         }
                         _ => panic!(),
                     }

--- a/src/data_hub.rs
+++ b/src/data_hub.rs
@@ -8,7 +8,7 @@ use crate::{DataConn, DataConnManager, DataHub, DataSrc, DataSrcManager, SendSyn
 #[allow(unused)] // for rustdoc
 use crate::DataAcc;
 
-use crate::DataConnContainer;
+use crate::{DataConnContainer, ErrEntry};
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -21,7 +21,7 @@ pub enum DataHubError {
     /// Contains a vector of data source names and their corresponding errors.
     FailToSetupLocalDataSrcs {
         /// The vector contains errors that occurred in each [`DataSrc`] object.
-        errors: Vec<(Arc<str>, errs::Err)>,
+        errors: Vec<ErrEntry>,
     },
 
     /// Indicates that no [`DataSrc`] was found to create a [`DataConn`] for the specified name
@@ -806,8 +806,9 @@ mod tests_of_data_hub {
                 match err.reason::<DataHubError>() {
                     Ok(DataHubError::FailToSetupLocalDataSrcs { errors }) => {
                         assert_eq!(errors.len(), 1);
-                        assert_eq!(errors[0].0, "bar".into());
-                        assert_eq!(errors[0].1.reason::<String>().unwrap(), "setup error");
+                        assert_eq!(errors[0].index, 1);
+                        assert_eq!(errors[0].name, "bar".into());
+                        assert_eq!(errors[0].err.reason::<String>().unwrap(), "setup error");
                     }
                     _ => panic!(),
                 }
@@ -1084,8 +1085,9 @@ mod tests_of_data_hub {
                 match e.reason::<DataConnError>() {
                     Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                         assert_eq!(errors.len(), 1);
-                        assert_eq!(errors[0].0, "foo".into());
-                        assert_eq!(errors[0].1.reason::<&str>().unwrap(), &"pre commit error");
+                        assert_eq!(errors[0].index, 0);
+                        assert_eq!(errors[0].name, "foo".into());
+                        assert_eq!(errors[0].err.reason::<&str>().unwrap(), &"pre commit error");
                     }
                     _ => panic!(),
                 }
@@ -1149,8 +1151,9 @@ mod tests_of_data_hub {
                 match e.reason::<DataConnError>() {
                     Ok(DataConnError::FailToCommitDataConn { errors }) => {
                         assert_eq!(errors.len(), 1);
-                        assert_eq!(errors[0].0, "foo".into());
-                        assert_eq!(errors[0].1.reason::<&str>().unwrap(), &"commit error");
+                        assert_eq!(errors[0].index, 0);
+                        assert_eq!(errors[0].name, "foo".into());
+                        assert_eq!(errors[0].err.reason::<&str>().unwrap(), &"commit error");
                     }
                     _ => panic!(),
                 }
@@ -1216,10 +1219,18 @@ mod tests_of_data_hub {
                 match e.reason::<DataConnError>() {
                     Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
                         assert_eq!(errors.len(), 2);
-                        assert_eq!(errors[0].0, "foo".into());
-                        assert_eq!(errors[0].1.reason::<&str>().unwrap(), &"post commit error");
-                        assert_eq!(errors[1].0, "bar".into());
-                        assert_eq!(errors[1].1.reason::<&str>().unwrap(), &"post commit error");
+                        assert_eq!(errors[0].index, 0);
+                        assert_eq!(errors[0].name, "foo".into());
+                        assert_eq!(
+                            errors[0].err.reason::<&str>().unwrap(),
+                            &"post commit error"
+                        );
+                        assert_eq!(errors[1].index, 1);
+                        assert_eq!(errors[1].name, "bar".into());
+                        assert_eq!(
+                            errors[1].err.reason::<&str>().unwrap(),
+                            &"post commit error"
+                        );
                     }
                     _ => panic!(),
                 }
@@ -1398,8 +1409,9 @@ mod tests_of_data_hub {
                 match e.reason::<DataHubError>() {
                     Ok(DataHubError::FailToSetupLocalDataSrcs { errors }) => {
                         assert_eq!(errors.len(), 1);
-                        assert_eq!(errors[0].0, "foo".into());
-                        assert_eq!(errors[0].1.reason::<String>().unwrap(), "setup error");
+                        assert_eq!(errors[0].index, 0);
+                        assert_eq!(errors[0].name, "foo".into());
+                        assert_eq!(errors[0].err.reason::<String>().unwrap(), "setup error");
                     }
                     _ => panic!(),
                 }

--- a/src/data_src/mod.rs
+++ b/src/data_src/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use global_setup::{
 pub use global_setup::{create_static_data_src_container, setup, setup_with_order, uses};
 
 use crate::{
-    AsyncGroup, DataConn, DataConnContainer, DataSrc, DataSrcContainer, DataSrcManager,
+    AsyncGroup, DataConn, DataConnContainer, DataSrc, DataSrcContainer, DataSrcManager, ErrEntry,
     SendSyncNonNull,
 };
 
@@ -32,7 +32,7 @@ pub enum DataSrcError {
     /// Contains a vector of data source names and their corresponding errors.
     FailToSetupGlobalDataSrcs {
         /// The vector contains errors that occurred in each [`DataSrc`] object.
-        errors: Vec<(Arc<str>, errs::Err)>,
+        errors: Vec<ErrEntry>,
     },
 
     /// Indicates that a setup process for global data sources is currently ongoing.
@@ -208,27 +208,31 @@ impl DataSrcManager {
         }
     }
 
-    pub(crate) fn setup(&mut self, errors: &mut Vec<(Arc<str>, errs::Err)>) {
+    pub(crate) fn setup(&mut self, errors: &mut Vec<ErrEntry>) {
         if self.vec_unready.is_empty() {
             return;
         }
-
-        let mut indexed_errors = Vec::<(usize, errs::Err)>::new();
 
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec_unready.iter().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let setup_fn = unsafe { (*ptr).setup_fn };
+            let name = unsafe { &(*ptr).name };
             ag._index = i;
+            ag._name = name.clone();
             if let Err(err) = setup_fn(ptr, &mut ag) {
-                indexed_errors.push((ag._index, err));
+                errors.push(ErrEntry {
+                    index: i,
+                    name: name.clone(),
+                    err,
+                });
                 break;
             }
         }
         let n_done = ag._index;
-        ag.join_and_collect_errors(&mut indexed_errors);
+        ag.join_and_collect_errors(errors);
 
-        if indexed_errors.is_empty() {
+        if errors.is_empty() {
             self.vec_ready.append(&mut self.vec_unready);
         } else {
             for ssnnptr in self.vec_unready[0..n_done].iter().rev() {
@@ -236,20 +240,10 @@ impl DataSrcManager {
                 let close_fn = unsafe { (*ptr).close_fn };
                 close_fn(ptr);
             }
-            for (i, err) in indexed_errors.into_iter() {
-                let ssnnptr = &self.vec_unready[i];
-                let ptr = ssnnptr.non_null_ptr.as_ptr();
-                let name = unsafe { (*ptr).name.clone() };
-                errors.push((name, err));
-            }
         }
     }
 
-    pub(crate) fn setup_with_order(
-        &mut self,
-        names: &[&str],
-        errors: &mut Vec<(Arc<str>, errs::Err)>,
-    ) {
+    pub(crate) fn setup_with_order(&mut self, names: &[&str], errors: &mut Vec<ErrEntry>) {
         if self.vec_unready.is_empty() {
             return;
         }
@@ -274,8 +268,6 @@ impl DataSrcManager {
             }
         }
 
-        let mut indexed_errors = Vec::<(usize, errs::Err)>::new();
-
         let mut ag = AsyncGroup::new();
         let mut n_done = 0;
         for vec_index_opt in ordered_indexes.iter() {
@@ -283,17 +275,23 @@ impl DataSrcManager {
                 let ssnnptr = &self.vec_unready[*vec_index];
                 let ptr = ssnnptr.non_null_ptr.as_ptr();
                 let setup_fn = unsafe { (*ptr).setup_fn };
+                let name = unsafe { &(*ptr).name };
                 ag._index = *vec_index;
+                ag._name = name.clone();
                 if let Err(err) = setup_fn(ptr, &mut ag) {
-                    indexed_errors.push((ag._index, err));
+                    errors.push(ErrEntry {
+                        index: *vec_index,
+                        name: name.clone(),
+                        err,
+                    });
                     break;
                 }
             }
             n_done += 1;
         }
-        ag.join_and_collect_errors(&mut indexed_errors);
+        ag.join_and_collect_errors(errors);
 
-        if indexed_errors.is_empty() {
+        if errors.is_empty() {
             let old_unready = mem::take(&mut self.vec_unready);
             // Maximizing performance by pre-allocating the required capacity.
             self.vec_ready
@@ -307,12 +305,6 @@ impl DataSrcManager {
                 let ptr = ssnnptr.non_null_ptr.as_ptr();
                 let close_fn = unsafe { (*ptr).close_fn };
                 close_fn(ptr);
-            }
-            for (vec_index, err) in indexed_errors.into_iter() {
-                let ssnnptr = &self.vec_unready[vec_index];
-                let ptr = ssnnptr.non_null_ptr.as_ptr();
-                let name = unsafe { (*ptr).name.clone() };
-                errors.push((name, err));
             }
         }
     }
@@ -868,11 +860,12 @@ mod tests_of_data_src {
             assert_eq!(manager.vec_ready.len(), 0);
 
             assert_eq!(errors.len(), 1);
-            assert_eq!(errors[0].0, "bar".into());
+            assert_eq!(errors[0].index, 1);
+            assert_eq!(errors[0].name, "bar".into());
             #[cfg(unix)]
-            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src/data_src/mod.rs, line = 461 }");
+            assert_eq!(format!("{:?}", errors[0].err), "errs::Err { reason = alloc::string::String \"XXX\", file = src/data_src/mod.rs, line = 453 }");
             #[cfg(windows)]
-            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src\\data_src\\mod.rs, line = 461 }");
+            assert_eq!(format!("{:?}", errors[0].err), "errs::Err { reason = alloc::string::String \"XXX\", file = src\\data_src\\mod.rs, line = 453 }");
         }
 
         assert_eq!(
@@ -971,11 +964,12 @@ mod tests_of_data_src {
             assert_eq!(manager.vec_ready.len(), 0);
 
             assert_eq!(errors.len(), 1);
-            assert_eq!(errors[0].0, "foo".into());
+            assert_eq!(errors[0].index, 0);
+            assert_eq!(errors[0].name, "foo".into());
             #[cfg(unix)]
-            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src/data_src/mod.rs, line = 461 }");
+            assert_eq!(format!("{:?}", errors[0].err), "errs::Err { reason = alloc::string::String \"XXX\", file = src/data_src/mod.rs, line = 453 }");
             #[cfg(windows)]
-            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src\\data_src\\mod.rs, line = 461 }");
+            assert_eq!(format!("{:?}", errors[0].err), "errs::Err { reason = alloc::string::String \"XXX\", file = src\\data_src\\mod.rs, line = 453 }");
         }
 
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,21 @@ pub use data_src::{create_static_data_src_container, setup, setup_with_order, us
 #[cfg(feature = "tokio")]
 pub mod tokio;
 
+/// Represents an entry containing an error, along with its context.
+///
+/// This structure is used to aggregate errors that occur during parallel
+/// or asynchronous operations, providing the index of the operation,
+/// a descriptive name, and the error itself.
+#[derive(Debug)]
+pub struct ErrEntry {
+    /// The index of the operation or handler that generated the error.
+    pub index: usize,
+    /// A descriptive name for the operation or context.
+    pub name: Arc<str>,
+    /// The actual error that occurred.
+    pub err: errs::Err,
+}
+
 /// The structure that allows for the concurrent execution of multiple functions
 /// using `std::thread` and waits for all of them to complete.
 ///
@@ -55,8 +70,9 @@ pub mod tokio;
 /// The `AsyncGroup` ensures that all tasks finish before proceeding,
 /// and can collect any errors that occur.
 pub struct AsyncGroup {
-    handlers: Vec<(usize, thread::JoinHandle<errs::Result<()>>)>,
+    handlers: Vec<(usize, Arc<str>, thread::JoinHandle<errs::Result<()>>)>,
     _index: usize,
+    _name: Arc<str>,
 }
 
 /// The trait that abstracts a connection per session to an external data service,

--- a/src/tokio/async_group.rs
+++ b/src/tokio/async_group.rs
@@ -2,7 +2,7 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-use super::AsyncGroup;
+use super::{AsyncGroup, ErrEntry};
 
 use futures::future;
 use std::future::Future;
@@ -11,8 +11,9 @@ impl AsyncGroup {
     pub(crate) fn new() -> Self {
         Self {
             tasks: Vec::new(),
-            indexes: Vec::new(),
+            attrs: Vec::new(),
             _index: 0,
+            _name: Default::default(),
         }
     }
 
@@ -30,10 +31,10 @@ impl AsyncGroup {
         Fut: Future<Output = errs::Result<()>> + Send + 'static,
     {
         self.tasks.push(Box::pin(future));
-        self.indexes.push(self._index);
+        self.attrs.push((self._index, self._name.clone()));
     }
 
-    pub(crate) async fn join_and_collect_errors_async(self, errors: &mut Vec<(usize, errs::Err)>) {
+    pub(crate) async fn join_and_collect_errors_async(self, errors: &mut Vec<ErrEntry>) {
         if self.tasks.is_empty() {
             return;
         }
@@ -41,7 +42,11 @@ impl AsyncGroup {
         let result_all = future::join_all(self.tasks).await;
         for (i, result) in result_all.into_iter().enumerate() {
             if let Err(err) = result {
-                errors.push((self.indexes[i], err));
+                errors.push(ErrEntry {
+                    index: self.attrs[i].0,
+                    name: self.attrs[i].1.clone(),
+                    err,
+                });
             }
         }
     }
@@ -155,6 +160,7 @@ mod tests_of_async_group {
             assert_eq!(*struct_a.string.lock().await, "a");
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             let mut errors = Vec::new();
@@ -172,6 +178,7 @@ mod tests_of_async_group {
             assert_eq!(*struct_a.string.lock().await, "a");
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             let mut errors = Vec::new();
@@ -180,15 +187,16 @@ mod tests_of_async_group {
             assert_eq!(errors.len(), 1);
             assert_eq!(*struct_a.string.lock().await, "a");
 
-            assert_eq!(errors[0].0, 12);
+            assert_eq!(errors[0].index, 12);
+            assert_eq!(errors[0].name, "foo".into());
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", errors[0].1),
+                format!("{:?}", errors[0].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"a\"), file = src/tokio/async_group.rs, line = ".to_string() + &(BASE_LINE + 30).to_string() + " }"
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", errors[0].1),
+                format!("{:?}", errors[0].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"a\"), file = src\\tokio\\async_group.rs, line = ".to_string() + &(BASE_LINE + 30).to_string() + " }"
             );
         }
@@ -207,12 +215,15 @@ mod tests_of_async_group {
             assert_eq!(*struct_c.string.lock().await, "c".to_string());
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag._index = 34;
+            ag._name = "bar".into();
             struct_b.process(&mut ag);
 
             ag._index = 56;
+            ag._name = "baz".into();
             struct_c.process(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -239,27 +250,31 @@ mod tests_of_async_group {
             assert_eq!(*struct_c.string.lock().await, "c");
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag._index = 34;
+            ag._name = "bar".into();
             struct_b.process(&mut ag);
 
             ag._index = 56;
+            ag._name = "baz".into();
             struct_c.process(&mut ag);
 
             let mut err_vec = Vec::new();
             ag.join_and_collect_errors_async(&mut err_vec).await;
 
             assert_eq!(err_vec.len(), 1);
-            assert_eq!(err_vec[0].0, 34);
+            assert_eq!(err_vec[0].index, 34);
+            assert_eq!(err_vec[0].name, "bar".into());
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", err_vec[0].1),
+                format!("{:?}", err_vec[0].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"b\"), file = src/tokio/async_group.rs, line = ".to_string() + &(BASE_LINE + 30).to_string() + " }",
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", err_vec[0].1),
+                format!("{:?}", err_vec[0].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"b\"), file = src\\tokio\\async_group.rs, line = ".to_string() + &(BASE_LINE + 30).to_string() + " }",
             );
 
@@ -282,12 +297,15 @@ mod tests_of_async_group {
             assert_eq!(*struct_c.string.lock().await, "c");
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag._index = 34;
+            ag._name = "bar".into();
             struct_b.process(&mut ag);
 
             ag._index = 56;
+            ag._name = "baz".into();
             struct_c.process(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -295,38 +313,42 @@ mod tests_of_async_group {
 
             assert_eq!(err_vec.len(), 3);
 
-            assert_eq!(err_vec[0].0, 12);
-            assert_eq!(err_vec[1].0, 34);
-            assert_eq!(err_vec[2].0, 56);
+            assert_eq!(err_vec[0].index, 12);
+            assert_eq!(err_vec[1].index, 34);
+            assert_eq!(err_vec[2].index, 56);
+
+            assert_eq!(err_vec[0].name, "foo".into());
+            assert_eq!(err_vec[1].name, "bar".into());
+            assert_eq!(err_vec[2].name, "baz".into());
 
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", err_vec[0].1),
+                format!("{:?}", err_vec[0].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"a\"), file = src/tokio/async_group.rs, line = ".to_string() + &(BASE_LINE + 30).to_string() + " }",
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", err_vec[0].1),
+                format!("{:?}", err_vec[0].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"a\"), file = src\\tokio\\async_group.rs, line = ".to_string() + &(BASE_LINE + 30).to_string() + " }",
             );
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", err_vec[1].1),
+                format!("{:?}", err_vec[1].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"b\"), file = src/tokio/async_group.rs, line = ".to_string() + &(BASE_LINE + 30).to_string() + " }",
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", err_vec[1].1),
+                format!("{:?}", err_vec[1].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"b\"), file = src\\tokio\\async_group.rs, line = ".to_string() + &(BASE_LINE + 30).to_string() + " }",
             );
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", err_vec[2].1),
+                format!("{:?}", err_vec[2].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"c\"), file = src/tokio/async_group.rs, line = ".to_string() + &(BASE_LINE + 30).to_string() + " }",
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", err_vec[2].1),
+                format!("{:?}", err_vec[2].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"c\"), file = src\\tokio\\async_group.rs, line = ".to_string() + &(BASE_LINE + 30).to_string() + " }",
             );
 
@@ -343,6 +365,7 @@ mod tests_of_async_group {
             assert_eq!(*struct_d.string.lock().await, "d");
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_d.process(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -361,6 +384,7 @@ mod tests_of_async_group {
             assert_eq!(*struct_d.string.lock().await, "d");
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_d.process_multiple(&mut ag);
 
             let mut err_vec = Vec::new();
@@ -368,28 +392,31 @@ mod tests_of_async_group {
 
             assert_eq!(err_vec.len(), 2);
 
-            assert_eq!(err_vec[0].0, 12);
-            assert_eq!(err_vec[1].0, 12);
+            assert_eq!(err_vec[0].index, 12);
+            assert_eq!(err_vec[1].index, 12);
+
+            assert_eq!(err_vec[0].name, "foo".into());
+            assert_eq!(err_vec[1].name, "foo".into());
 
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", err_vec[0].1),
+                format!("{:?}", err_vec[0].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"d\"), file = src/tokio/async_group.rs, line = ".to_string() + &(BASE_LINE + 49).to_string() + " }",
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", err_vec[0].1),
+                format!("{:?}", err_vec[0].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"d\"), file = src\\tokio\\async_group.rs, line = ".to_string() + &(BASE_LINE + 49).to_string() + " }"
             );
 
             #[cfg(unix)]
             assert_eq!(
-                format!("{:?}", err_vec[1].1),
+                format!("{:?}", err_vec[1].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"d\"), file = src/tokio/async_group.rs, line = ".to_string() + &(BASE_LINE + 66).to_string() + " }",
             );
             #[cfg(windows)]
             assert_eq!(
-                format!("{:?}", err_vec[1].1),
+                format!("{:?}", err_vec[1].err),
                 "errs::Err { reason = sabi::tokio::async_group::tests_of_async_group::Reasons BadString(\"d\"), file = src\\tokio\\async_group.rs, line = ".to_string() + &(BASE_LINE + 66).to_string() + " }"
             );
 
@@ -415,6 +442,7 @@ mod tests_of_async_group {
             assert_eq!(*struct_a.string.lock().await, "a".to_string());
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag.join_and_ignore_errors_async().await;
@@ -429,6 +457,7 @@ mod tests_of_async_group {
             assert_eq!(*struct_a.string.lock().await, "a".to_string());
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag.join_and_ignore_errors_async().await;
@@ -449,12 +478,15 @@ mod tests_of_async_group {
             assert_eq!(*struct_c.string.lock().await, "c".to_string());
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag._index = 34;
+            ag._name = "bar".into();
             struct_b.process(&mut ag);
 
             ag._index = 56;
+            ag._name = "baz".into();
             struct_c.process(&mut ag);
 
             ag.join_and_ignore_errors_async().await;
@@ -478,12 +510,15 @@ mod tests_of_async_group {
             assert_eq!(*struct_c.string.lock().await, "c".to_string());
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag._index = 34;
+            ag._name = "bar".into();
             struct_b.process(&mut ag);
 
             ag._index = 56;
+            ag._name = "baz".into();
             struct_c.process(&mut ag);
 
             ag.join_and_ignore_errors_async().await;
@@ -507,12 +542,15 @@ mod tests_of_async_group {
             assert_eq!(*struct_c.string.lock().await, "c".to_string());
 
             ag._index = 12;
+            ag._name = "foo".into();
             struct_a.process(&mut ag);
 
             ag._index = 34;
+            ag._name = "bar".into();
             struct_b.process(&mut ag);
 
             ag._index = 56;
+            ag._name = "baz".into();
             struct_c.process(&mut ag);
 
             ag.join_and_ignore_errors_async().await;

--- a/src/tokio/data_conn.rs
+++ b/src/tokio/data_conn.rs
@@ -2,7 +2,7 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-use super::{AsyncGroup, DataConn, DataConnContainer, DataConnManager, SendSyncNonNull};
+use super::{AsyncGroup, DataConn, DataConnContainer, DataConnManager, ErrEntry, SendSyncNonNull};
 use crate::{TxnFailureCause, TxnFailureReport, TxnFailureRollback};
 
 use std::collections::HashMap;
@@ -18,19 +18,19 @@ pub enum DataConnError {
     /// An error indicating that one or more data connections failed during the pre-commit process.
     FailToPreCommitDataConn {
         /// A vector of errors, each containing the name of the data connection and the error itself.
-        errors: Vec<(Arc<str>, errs::Err)>,
+        errors: Vec<ErrEntry>,
     },
 
     /// An error indicating that one or more data connections failed during the commit process.
     FailToCommitDataConn {
         /// A vector of errors, each containing the name of the data connection and the error itself.
-        errors: Vec<(Arc<str>, errs::Err)>,
+        errors: Vec<ErrEntry>,
     },
 
     /// An error indicating that one or more data connections failed during the post-commit process.
     FailToPostCommitDataConn {
         /// A vector of errors, each containing the name of the data connection and the error itself.
-        errors: Vec<(Arc<str>, errs::Err)>,
+        errors: Vec<ErrEntry>,
     },
 
     /// An error indicating that a data connection could not be cast to the target type.
@@ -255,26 +255,30 @@ impl DataConnManager {
         &mut self,
         reports: &mut [TxnFailureReport],
     ) -> errs::Result<()> {
-        let mut indexed_errors = Vec::new();
+        let mut errors = Vec::new();
 
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let pre_commit_fn = unsafe { (*ptr).pre_commit_fn };
+            let name = unsafe { &(*ptr).name };
             ag._index = i;
+            ag._name = name.clone();
             if let Err(err) = pre_commit_fn(ptr, &mut ag).await {
-                indexed_errors.push((ag._index, err));
+                errors.push(ErrEntry {
+                    index: i,
+                    name: name.clone(),
+                    err,
+                });
                 break;
             }
         }
-        ag.join_and_collect_errors_async(&mut indexed_errors).await;
+        ag.join_and_collect_errors_async(&mut errors).await;
 
-        if !indexed_errors.is_empty() {
-            let mut errors = Vec::new();
-            for (i, err) in indexed_errors.into_iter() {
-                let report = &mut reports[i];
-                report.cause = TxnFailureCause::LogicFailure(err.clone());
-                errors.push((report.data_conn_name.clone(), err));
+        if !errors.is_empty() {
+            for ee in errors.iter() {
+                let report = &mut reports[ee.index];
+                report.cause = TxnFailureCause::LogicFailure(ee.err.clone());
             }
             return Err(errs::Err::new(DataConnError::FailToPreCommitDataConn {
                 errors,
@@ -291,20 +295,24 @@ impl DataConnManager {
                 continue;
             }
             let commit_fn = unsafe { (*ptr).commit_fn };
+            let name = unsafe { &(*ptr).name };
             ag._index = i;
+            ag._name = name.clone();
             if let Err(err) = commit_fn(ptr, &mut ag).await {
-                indexed_errors.push((ag._index, err));
+                errors.push(ErrEntry {
+                    index: i,
+                    name: name.clone(),
+                    err,
+                });
                 break;
             }
         }
-        ag.join_and_collect_errors_async(&mut indexed_errors).await;
+        ag.join_and_collect_errors_async(&mut errors).await;
 
-        if !indexed_errors.is_empty() {
-            let mut errors = Vec::new();
-            for (i, err) in indexed_errors.into_iter() {
-                let report = &mut reports[i];
-                report.cause = TxnFailureCause::CommitFailure(err.clone());
-                errors.push((report.data_conn_name.clone(), err));
+        if !errors.is_empty() {
+            for ee in errors.iter() {
+                let report = &mut reports[ee.index];
+                report.cause = TxnFailureCause::CommitFailure(ee.err.clone());
             }
             return Err(errs::Err::new(DataConnError::FailToCommitDataConn {
                 errors,
@@ -317,20 +325,24 @@ impl DataConnManager {
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let post_commit_fn = unsafe { (*ptr).post_commit_fn };
+            let name = unsafe { &(*ptr).name };
             ag._index = i;
+            ag._name = name.clone();
             if let Err(err) = post_commit_fn(ptr, &mut ag).await {
-                indexed_errors.push((ag._index, err));
+                errors.push(ErrEntry {
+                    index: i,
+                    name: name.clone(),
+                    err,
+                });
                 // don't break;
             }
         }
-        ag.join_and_collect_errors_async(&mut indexed_errors).await;
+        ag.join_and_collect_errors_async(&mut errors).await;
 
-        if !indexed_errors.is_empty() {
-            let mut errors = Vec::new();
-            for (i, err) in indexed_errors.into_iter() {
-                let report = &mut reports[i];
-                report.cause = TxnFailureCause::PostCommitFailure(err.clone());
-                errors.push((report.data_conn_name.clone(), err));
+        if !errors.is_empty() {
+            for ee in errors.iter() {
+                let report = &mut reports[ee.index];
+                report.cause = TxnFailureCause::PostCommitFailure(ee.err.clone());
             }
             return Err(errs::Err::new(DataConnError::FailToPostCommitDataConn {
                 errors,
@@ -341,7 +353,7 @@ impl DataConnManager {
     }
 
     pub(crate) async fn rollback_async(&mut self, mut reports: Vec<TxnFailureReport>) {
-        let mut indexed_errors = Vec::new();
+        let mut errors = Vec::new();
 
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec.iter().flatten().enumerate() {
@@ -358,19 +370,25 @@ impl DataConnManager {
                 continue;
             }
             let rollback_fn = unsafe { (*ptr).rollback_fn };
+            let name = unsafe { &(*ptr).name };
             ag._index = i;
+            ag._name = name.clone();
             if let Err(err) = rollback_fn(ptr, &mut ag).await {
-                indexed_errors.push((ag._index, err));
+                errors.push(ErrEntry {
+                    index: i,
+                    name: name.clone(),
+                    err,
+                });
             } else {
                 report.rollback = TxnFailureRollback::NoneByRolledBack;
             }
         }
-        ag.join_and_collect_errors_async(&mut indexed_errors).await;
+        ag.join_and_collect_errors_async(&mut errors).await;
 
-        if !indexed_errors.is_empty() {
-            for (i, err) in indexed_errors.into_iter() {
-                let report = &mut reports[i];
-                report.rollback = TxnFailureRollback::RollbackFailure(err);
+        if !errors.is_empty() {
+            for ee in errors.into_iter() {
+                let report = &mut reports[ee.index];
+                report.rollback = TxnFailureRollback::RollbackFailure(ee.err);
             }
         }
 
@@ -1147,8 +1165,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "zzz");
+                            assert_eq!(errors[0].index, 0);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "zzz");
                         }
                         _ => panic!(),
                     }
@@ -1222,8 +1241,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "zzz");
+                            assert_eq!(errors[0].index, 0);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "zzz");
                         }
                         _ => panic!(),
                     }
@@ -1291,8 +1311,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "yyy");
+                            assert_eq!(errors[0].index, 0);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "yyy");
                         }
                         _ => panic!(),
                     }
@@ -1347,8 +1368,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "ZZZ");
+                            assert_eq!(errors[0].index, 0);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "ZZZ");
                         }
                         _ => panic!(),
                     }
@@ -1426,8 +1448,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "YYY");
+                            assert_eq!(errors[0].index, 0);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "YYY");
                         }
                         _ => panic!(),
                     }
@@ -1505,8 +1528,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "bar".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "YYY");
+                            assert_eq!(errors[0].index, 1);
+                            assert_eq!(errors[0].name, "bar".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "YYY");
                         }
                         _ => panic!(),
                     }
@@ -1584,10 +1608,12 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 2);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "!!!");
-                            assert_eq!(errors[1].0, "bar".into());
-                            assert_eq!(errors[1].1.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[0].index, 0);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[1].index, 1);
+                            assert_eq!(errors[1].name, "bar".into());
+                            assert_eq!(errors[1].err.reason::<String>().unwrap(), "!!!");
                         }
                         _ => panic!(),
                     }
@@ -1667,10 +1693,12 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 2);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "!!!");
-                            assert_eq!(errors[1].0, "bar".into());
-                            assert_eq!(errors[1].1.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[0].index, 1);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[1].index, 0);
+                            assert_eq!(errors[1].name, "bar".into());
+                            assert_eq!(errors[1].err.reason::<String>().unwrap(), "!!!");
                         }
                         _ => panic!(),
                     }
@@ -1744,8 +1772,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "foo".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "!!!");
+                            assert_eq!(errors[0].index, 1);
+                            assert_eq!(errors[0].name, "foo".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "!!!");
                         }
                         _ => panic!(),
                     }
@@ -2008,8 +2037,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "bar".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "ZZZ");
+                            assert_eq!(errors[0].index, 0);
+                            assert_eq!(errors[0].name, "bar".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "ZZZ");
                         }
                         _ => panic!(),
                     }
@@ -2083,8 +2113,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "bar".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "YYY");
+                            assert_eq!(errors[0].index, 1);
+                            assert_eq!(errors[0].name, "bar".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "YYY");
                         }
                         _ => panic!(),
                     }
@@ -2202,8 +2233,9 @@ mod tests_of_data_conn {
                     match e.reason::<DataConnError>() {
                         Ok(DataConnError::FailToCommitDataConn { errors }) => {
                             assert_eq!(errors.len(), 1);
-                            assert_eq!(errors[0].0, "bar".into());
-                            assert_eq!(errors[0].1.reason::<String>().unwrap(), "YYY");
+                            assert_eq!(errors[0].index, 1);
+                            assert_eq!(errors[0].name, "bar".into());
+                            assert_eq!(errors[0].err.reason::<String>().unwrap(), "YYY");
                         }
                         _ => panic!(),
                     }

--- a/src/tokio/data_hub.rs
+++ b/src/tokio/data_hub.rs
@@ -3,8 +3,10 @@
 // See the file LICENSE in this distribution for more details.
 
 use super::data_src::{copy_global_data_srcs_to_map, create_data_conn_from_global_data_src_async};
-use super::{DataConn, DataConnContainer, DataConnManager, DataHub, DataSrc, DataSrcManager};
-use crate::SendSyncNonNull;
+use super::{
+    DataConn, DataConnContainer, DataConnManager, DataHub, DataSrc, DataSrcManager, ErrEntry,
+    SendSyncNonNull,
+};
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -18,7 +20,7 @@ pub enum DataHubError {
     /// An error indicating that one or more local data sources failed during their setup processes.
     FailToSetupLocalDataSrcs {
         /// A vector of errors, each containing the name of the data source and the error itself.
-        errors: Vec<(Arc<str>, errs::Err)>,
+        errors: Vec<ErrEntry>,
     },
 
     /// An error indicating that no suitable data source was found to create a data connection
@@ -839,8 +841,9 @@ mod tests_of_data_hub {
                 match err.reason::<DataHubError>() {
                     Ok(DataHubError::FailToSetupLocalDataSrcs { errors }) => {
                         assert_eq!(errors.len(), 1);
-                        assert_eq!(errors[0].0, "bar".into());
-                        assert_eq!(errors[0].1.reason::<String>().unwrap(), "setup error");
+                        assert_eq!(errors[0].index, 1);
+                        assert_eq!(errors[0].name, "bar".into());
+                        assert_eq!(errors[0].err.reason::<String>().unwrap(), "setup error");
                     }
                     _ => panic!(),
                 }
@@ -1147,8 +1150,9 @@ mod tests_of_data_hub {
                 match e.reason::<DataConnError>() {
                     Ok(DataConnError::FailToPreCommitDataConn { errors }) => {
                         assert_eq!(errors.len(), 1);
-                        assert_eq!(errors[0].0, "foo".into());
-                        assert_eq!(errors[0].1.reason::<&str>().unwrap(), &"pre commit error");
+                        assert_eq!(errors[0].index, 0);
+                        assert_eq!(errors[0].name, "foo".into());
+                        assert_eq!(errors[0].err.reason::<&str>().unwrap(), &"pre commit error");
                     }
                     _ => panic!("{e:?}"),
                 }
@@ -1218,8 +1222,9 @@ mod tests_of_data_hub {
                 match e.reason::<DataConnError>() {
                     Ok(DataConnError::FailToCommitDataConn { errors }) => {
                         assert_eq!(errors.len(), 1);
-                        assert_eq!(errors[0].0, "foo".into());
-                        assert_eq!(errors[0].1.reason::<&str>().unwrap(), &"commit error");
+                        assert_eq!(errors[0].index, 0);
+                        assert_eq!(errors[0].name, "foo".into());
+                        assert_eq!(errors[0].err.reason::<&str>().unwrap(), &"commit error");
                     }
                     _ => panic!("{e:?}"),
                 }
@@ -1291,10 +1296,18 @@ mod tests_of_data_hub {
                 match e.reason::<DataConnError>() {
                     Ok(DataConnError::FailToPostCommitDataConn { errors }) => {
                         assert_eq!(errors.len(), 2);
-                        assert_eq!(errors[0].0, "foo".into());
-                        assert_eq!(errors[0].1.reason::<&str>().unwrap(), &"post commit error");
-                        assert_eq!(errors[1].0, "bar".into());
-                        assert_eq!(errors[1].1.reason::<&str>().unwrap(), &"post commit error");
+                        assert_eq!(errors[0].index, 0);
+                        assert_eq!(errors[0].name, "foo".into());
+                        assert_eq!(
+                            errors[0].err.reason::<&str>().unwrap(),
+                            &"post commit error"
+                        );
+                        assert_eq!(errors[1].index, 1);
+                        assert_eq!(errors[1].name, "bar".into());
+                        assert_eq!(
+                            errors[1].err.reason::<&str>().unwrap(),
+                            &"post commit error"
+                        );
                     }
                     _ => panic!("{e:?}"),
                 }
@@ -1484,8 +1497,9 @@ mod tests_of_data_hub {
                 match e.reason::<DataHubError>() {
                     Ok(DataHubError::FailToSetupLocalDataSrcs { errors }) => {
                         assert_eq!(errors.len(), 1);
-                        assert_eq!(errors[0].0, "foo".into());
-                        assert_eq!(errors[0].1.reason::<String>().unwrap(), "setup error");
+                        assert_eq!(errors[0].index, 0);
+                        assert_eq!(errors[0].name, "foo".into());
+                        assert_eq!(errors[0].err.reason::<String>().unwrap(), "setup error");
                     }
                     _ => panic!(),
                 }

--- a/src/tokio/data_src/mod.rs
+++ b/src/tokio/data_src/mod.rs
@@ -12,7 +12,7 @@ pub use global_setup::{
 };
 
 use crate::tokio::{
-    AsyncGroup, DataConn, DataConnContainer, DataSrc, DataSrcContainer, DataSrcManager,
+    AsyncGroup, DataConn, DataConnContainer, DataSrc, DataSrcContainer, DataSrcManager, ErrEntry,
     SendSyncNonNull,
 };
 
@@ -35,7 +35,7 @@ pub enum DataSrcError {
     /// An error indicating that one or more global data sources failed during their setup process.
     FailToSetupGlobalDataSrcs {
         /// A vector of errors, each containing the name of the data source and the error itself.
-        errors: Vec<(Arc<str>, errs::Err)>,
+        errors: Vec<ErrEntry>,
     },
 
     /// An error indicating that a global data source setup is currently in progress.
@@ -221,27 +221,31 @@ impl DataSrcManager {
         }
     }
 
-    pub(crate) async fn setup_async(&mut self, errors: &mut Vec<(Arc<str>, errs::Err)>) {
+    pub(crate) async fn setup_async(&mut self, errors: &mut Vec<ErrEntry>) {
         if self.vec_unready.is_empty() {
             return;
         }
-
-        let mut indexed_errors = Vec::<(usize, errs::Err)>::new();
 
         let mut ag = AsyncGroup::new();
         for (i, ssnnptr) in self.vec_unready.iter().enumerate() {
             let ptr = ssnnptr.non_null_ptr.as_ptr();
             let setup_fn = unsafe { (*ptr).setup_fn };
+            let name = unsafe { &(*ptr).name };
             ag._index = i;
+            ag._name = name.clone();
             if let Err(err) = setup_fn(ptr, &mut ag).await {
-                indexed_errors.push((ag._index, err));
+                errors.push(ErrEntry {
+                    index: i,
+                    name: name.clone(),
+                    err,
+                });
                 break;
             }
         }
         let n_done = ag._index;
-        ag.join_and_collect_errors_async(&mut indexed_errors).await;
+        ag.join_and_collect_errors_async(errors).await;
 
-        if indexed_errors.is_empty() {
+        if errors.is_empty() {
             self.vec_ready.append(&mut self.vec_unready);
         } else {
             for ssnnptr in self.vec_unready[0..n_done].iter().rev() {
@@ -249,19 +253,13 @@ impl DataSrcManager {
                 let close_fn = unsafe { (*ptr).close_fn };
                 close_fn(ptr);
             }
-            for (i, err) in indexed_errors.into_iter() {
-                let ssnnptr = &self.vec_unready[i];
-                let ptr = ssnnptr.non_null_ptr.as_ptr();
-                let name = unsafe { (*ptr).name.clone() };
-                errors.push((name, err));
-            }
         }
     }
 
     pub(crate) async fn setup_with_order_async(
         &mut self,
         names: &[&str],
-        errors: &mut Vec<(Arc<str>, errs::Err)>,
+        errors: &mut Vec<ErrEntry>,
     ) {
         if self.vec_unready.is_empty() {
             return;
@@ -287,8 +285,6 @@ impl DataSrcManager {
             }
         }
 
-        let mut indexed_errors = Vec::<(usize, errs::Err)>::new();
-
         let mut ag = AsyncGroup::new();
         let mut n_done = 0;
         for vec_index_opt in ordered_indexes.iter() {
@@ -296,17 +292,23 @@ impl DataSrcManager {
                 let ssnnptr = &self.vec_unready[*vec_index];
                 let ptr = ssnnptr.non_null_ptr.as_ptr();
                 let setup_fn = unsafe { (*ptr).setup_fn };
+                let name = unsafe { &(*ptr).name };
                 ag._index = *vec_index;
+                ag._name = name.clone();
                 if let Err(err) = setup_fn(ptr, &mut ag).await {
-                    indexed_errors.push((ag._index, err));
+                    errors.push(ErrEntry {
+                        index: *vec_index,
+                        name: name.clone(),
+                        err,
+                    });
                     break;
                 }
             }
             n_done += 1;
         }
-        ag.join_and_collect_errors_async(&mut indexed_errors).await;
+        ag.join_and_collect_errors_async(errors).await;
 
-        if indexed_errors.is_empty() {
+        if errors.is_empty() {
             let old_unready = mem::take(&mut self.vec_unready);
             // Maximizing performance by pre-allocating the required capacity.
             self.vec_ready
@@ -320,12 +322,6 @@ impl DataSrcManager {
                 let ptr = ssnnptr.non_null_ptr.as_ptr();
                 let close_fn = unsafe { (*ptr).close_fn };
                 close_fn(ptr);
-            }
-            for (vec_index, err) in indexed_errors.into_iter() {
-                let ssnnptr = &self.vec_unready[vec_index];
-                let ptr = ssnnptr.non_null_ptr.as_ptr();
-                let name = unsafe { (*ptr).name.clone() };
-                errors.push((name, err));
             }
         }
     }
@@ -999,11 +995,12 @@ mod tests_of_data_src {
             assert_eq!(manager.vec_ready.len(), 0);
 
             assert_eq!(errors.len(), 1);
-            assert_eq!(errors[0].0, "foo".into());
+            assert_eq!(errors[0].index, 0);
+            assert_eq!(errors[0].name, "foo".into());
             #[cfg(unix)]
-            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src/tokio/data_src/mod.rs, line = 486 }");
+            assert_eq!(format!("{:?}", errors[0].err), "errs::Err { reason = alloc::string::String \"XXX\", file = src/tokio/data_src/mod.rs, line = 482 }");
             #[cfg(windows)]
-            assert_eq!(format!("{:?}", errors[0].1), "errs::Err { reason = alloc::string::String \"XXX\", file = src\\tokio\\data_src\\mod.rs, line = 486 }");
+            assert_eq!(format!("{:?}", errors[0].err), "errs::Err { reason = alloc::string::String \"XXX\", file = src\\tokio\\data_src\\mod.rs, line = 482 }");
         }
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -16,7 +16,7 @@ mod data_conn;
 mod data_hub;
 mod data_src;
 
-use crate::{SendSyncNonNull, TxnFailureReport};
+use crate::{ErrEntry, SendSyncNonNull, TxnFailureReport};
 
 use std::any;
 use std::collections::HashMap;
@@ -77,9 +77,10 @@ pub use crate::_uses_for_async as uses;
 /// and can collect any errors that occur.
 #[allow(clippy::type_complexity)]
 pub struct AsyncGroup {
-    indexes: Vec<usize>,
+    attrs: Vec<(usize, Arc<str>)>,
     tasks: Vec<Pin<Box<dyn Future<Output = errs::Result<()>> + Send + 'static>>>,
     _index: usize,
+    _name: Arc<str>,
 }
 
 /// The asynchronous trait for data connection implementations, providing methods for transaction


### PR DESCRIPTION
## Overview
Replaces the tuple-based representation `(usize, errs::Err)` or `(Arc<str>, errs::Err)` with a structured `ErrEntry` struct in modules that handle multiple errors, such as `AsyncGroup` and `DataConn`.

## Purpose
- **Improved Readability**: Using explicit field names (`index`, `name`, `err`) makes the data structure self-explanatory compared to accessing tuple elements by index (e.g., `h.0`).
- **Enhanced Maintainability**: Removing magic-number-based access makes the code more resilient to future structural changes.
- **Consistency**: Centralizing the error entry definition ensures a consistent error handling pattern across the codebase.

## Key Changes
- Defined the `ErrEntry` struct in `src/lib.rs`.
- Refactored `AsyncGroup`, `DataConn`, and their associated methods to utilize `ErrEntry` instead of tuples.
- Updated all relevant tests to use field-based access for `ErrEntry`.

## Impact
- The type signature of `Vec`s holding error entries has been updated.
- Existing tests have been updated to align with the new structure.